### PR TITLE
refactor: use npm-registry-fetch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: node_js
 sudo: false
 node_js:
+  - "10"
   - "9"
   - "8"
   - "6"
+cache:
+  directories:
+    - /home/travis/.npm

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 environment:
   matrix:
+    - nodejs_version: "10"
     - nodejs_version: "9"
     - nodejs_version: "8"
     - nodejs_version: "6"

--- a/lib/README.md
+++ b/lib/README.md
@@ -4,9 +4,8 @@ Provides functions for fetching and updating an npmjs.com profile.
 
 ```js
 const profile = require('npm-profile')
-profile.get(registry, {token}).then(result => {
-   // …
-})
+const result = await profile.get(registry, {token})
+//...
 ```
 
 The API that this implements is documented here:
@@ -14,22 +13,37 @@ The API that this implements is documented here:
 * [authentication](https://github.com/npm/registry/blob/master/docs/user/authentication.md)
 * [profile editing](https://github.com/npm/registry/blob/master/docs/user/profile.md) (and two-factor authentication)
 
-## Functions
+## Table of Contents
 
-### profile.adduser(opener, prompter, config) → Promise
+* [API](#api)
+  * Login and Account Creation
+    * [`adduser()`](#adduser)
+    * [`login()`](#login)
+    * [`adduserWeb()`](#adduser-web)
+    * [`loginWeb()`](#login-web)
+    * [`adduserCouch()`](#adduser-couch)
+    * [`loginCouch()`](#login-couch)
+  * Profile Data Management
+    * [`get()`](#get)
+    * [`set()`](#set)
+  * Token Management
+    * [`listTokens()`](#list-tokens)
+    * [`removeToken()`](#remove-token)
+    * [`createToken()`](#create-token)
+
+## API
+
+### <a name="adduser"></a> `> profile.adduser(opener, prompter, [opts]) → Promise`
 
 Tries to create a user new web based login, if that fails it falls back to
 using the legacy CouchDB APIs.
 
 * `opener` Function (url) → Promise, returns a promise that resolves after a browser has been opened for the user at `url`.
 * `prompter` Function (creds) → Promise, returns a promise that resolves to an object with `username`, `email` and `password` properties.
-* `config` Object
+* [`opts`](#opts) Object (optional) plus extra keys:
   * `creds` Object, passed through to prompter, common values are:
     * `username` String, default value for username
     * `email` String, default value for email
-  * `registry` String (for reference, the npm registry is `https://registry.npmjs.org`)
-  * `opts` Object, [make-fetch-happen options](https://www.npmjs.com/package/make-fetch-happen#extra-options) for setting
-    things like cache, proxy, SSL CA and retry rules.
 
 #### **Promise Value**
 
@@ -50,21 +64,16 @@ on this account isn't allowed from then the `code` will be set to `EAUTHIP`.
 Otherwise the code will be `'E'` followed by the HTTP response code, for
 example a Forbidden response would be `E403`.
 
-### profile.login(opener, prompter, config) → Promise
+### <a name="login"></a> `> profile.login(opener, prompter, [opts]) → Promise`
 
 Tries to login using new web based login, if that fails it falls back to
 using the legacy CouchDB APIs.
 
 * `opener` Function (url) → Promise, returns a promise that resolves after a browser has been opened for the user at `url`.
 * `prompter` Function (creds) → Promise, returns a promise that resolves to an object with `username`, and `password` properties.
-* `config` Object
+* [`opts`](#opts) Object (optional) plus extra keys:
   * `creds` Object, passed through to prompter, common values are:
     * `name` String, default value for username
-  * `registry` String (for reference, the npm registry is `https://registry.npmjs.org`)
-  * `auth` Object, properties: `otp`
-    the one-time password from a two-factor authentication device.
-  * `opts` Object, [make-fetch-happen options](https://www.npmjs.com/package/make-fetch-happen#extra-options) for setting
-    things like cache, proxy, SSL CA and retry rules.
 
 #### **Promise Value**
 
@@ -89,16 +98,13 @@ on this account isn't allowed from then the `code` will be set to `EAUTHIP`.
 Otherwise the code will be `'E'` followed by the HTTP response code, for
 example a Forbidden response would be `E403`.
 
-### profile.adduserWeb(opener, config) → Promise
+### <a name="adduser-web"></a> `> profile.adduserWeb(opener, [opts]) → Promise`
 
 Tries to create a user new web based login, if that fails it falls back to
 using the legacy CouchDB APIs.
 
 * `opener` Function (url) → Promise, returns a promise that resolves after a browser has been opened for the user at `url`.
-* `config` Object
-  * `registry` String (for reference, the npm registry is `https://registry.npmjs.org`)
-  * `opts` Object, [make-fetch-happen options](https://www.npmjs.com/package/make-fetch-happen#extra-options) for setting
-    things like cache, proxy, SSL CA and retry rules.
+* [`opts`](#opts) Object
 
 #### **Promise Value**
 
@@ -123,16 +129,13 @@ on this account isn't allowed from then the `code` will be set to `EAUTHIP`.
 Otherwise the code will be `'E'` followed by the HTTP response code, for
 example a Forbidden response would be `E403`.
 
-### profile.loginWeb(opener, config) → Promise
+### <a name="login-web"></a> `> profile.loginWeb(opener, [opts]) → Promise`
 
 Tries to login using new web based login, if that fails it falls back to
 using the legacy CouchDB APIs.
 
 * `opener` Function (url) → Promise, returns a promise that resolves after a browser has been opened for the user at `url`.
-* `config` Object
-  * `registry` String (for reference, the npm registry is `https://registry.npmjs.org`)
-  * `opts` Object, [make-fetch-happen options](https://www.npmjs.com/package/make-fetch-happen#extra-options) for setting
-    things like cache, proxy, SSL CA and retry rules.
+* [`opts`](#opts) Object (optional)
 
 #### **Promise Value**
 
@@ -151,19 +154,17 @@ If the registry does not support web-login then an error will be thrown with
 its `code` property set to `ENYI` . You should retry with `loginCouch`.
 If you use `login` then this fallback will be done automatically.
 
-
 If the action was denied because it came from an IP address that this action
 on this account isn't allowed from then the `code` will be set to `EAUTHIP`.
 
 Otherwise the code will be `'E'` followed by the HTTP response code, for
 example a Forbidden response would be `E403`.
 
-### profile.adduserCouch(username, email, password, config) → Promise
+### <a name="adduser-couch"></a> `> profile.adduserCouch(username, email, password, [opts]) → Promise`
 
 ```js
-profile.adduser(username, email, password, {registry}).then(result => {
-  // do something with result.token
-})
+const {token} = await profile.adduser(username, email, password, {registry})
+// `token` can be passed in through `opts` for authentication.
 ```
 
 Creates a new user on the server along with a fresh bearer token for future
@@ -176,10 +177,7 @@ this is registry specific and not guaranteed.
 * `username` String
 * `email` String
 * `password` String
-* `config` Object
-  * `registry` String (for reference, the npm registry is `https://registry.npmjs.org`)
-  * `opts` Object, [make-fetch-happen options](https://www.npmjs.com/package/make-fetch-happen#extra-options) for setting
-    things like cache, proxy, SSL CA and retry rules.
+* [`opts`](#opts) Object (optional)
 
 #### **Promise Value**
 
@@ -203,33 +201,29 @@ on this account isn't allowed from then the `code` will be set to `EAUTHIP`.
 Otherwise the code will be `'E'` followed by the HTTP response code, for
 example a Forbidden response would be `E403`.
 
-### profile.loginCouch(username, password, config) → Promise
+### <a name="login-couch"></a> `> profile.loginCouch(username, password, [opts]) → Promise`
 
 ```js
-profile.login(username, password, {registry}).catch(err => {
+let token
+try {
+  {token} = await profile.login(username, password, {registry})
+} catch (err) {
   if (err.code === 'otp') {
-    return getOTPFromSomewhere().then(otp => {
-      return profile.login(username, password, {registry, auth: {otp}})
-    })
+    const otp = await getOTPFromSomewhere()
+    {token} = await profile.login(username, password, {otp})
   }
-}).then(result => {
-  // do something with result.token
-})
+}
+// `token` can now be passed in through `opts` for authentication.
 ```
 
 Logs you into an existing user.  Does not create the user if they do not
 already exist.  Logging in means generating a new bearer token for use in
 future authentication. This is what you use as an `authToken` in an `.npmrc`.
- 
+
 * `username` String
 * `email` String
 * `password` String
-* `config` Object
-  * `registry` String (for reference, the npm registry is `https://registry.npmjs.org`)
-  * `auth` Object, properties: `otp` — the one-time password from a two-factor
-    authentication device.
-  * `opts` Object, [make-fetch-happen options](https://www.npmjs.com/package/make-fetch-happen#extra-options) for setting
-    things like cache, proxy, SSL CA and retry rules.
+* [`opts`](#opts) Object (optional)
 
 #### **Promise Value**
 
@@ -254,24 +248,16 @@ If the error was neither of these then the error object will have a
 `code` property set to the HTTP response code and a `headers` property with
 the HTTP headers in the response.
 
-### profile.get(config) → Promise
+### <a name="get"></a> `> profile.get([opts]) → Promise`
 
 ```js
-profile.get(registry, {auth: {token}}).then(userProfile => {
-  // do something with userProfile
-})
+const {name, email} = await profile.get({token})
+console.log(`${token} belongs to https://npm.im/~${name}, (mailto:${email})`)
 ```
 
 Fetch profile information for the authenticated user.
- 
-* `config` Object
-  * `registry` String (for reference, the npm registry is `https://registry.npmjs.org`)
-  * `auth` Object, properties: `token` — a bearer token returned from
-    `adduser`, `login` or `createToken`, or, `username`, `password` (and
-    optionally `otp`).  Authenticating for this command via a username and
-    password will likely not be supported in the future.
-  * `opts` Object, [make-fetch-happen options](https://www.npmjs.com/package/make-fetch-happen#extra-options) for setting
-    things like cache, proxy, SSL CA and retry rules.
+
+* [`opts`](#opts) Object
 
 #### **Promise Value**
 
@@ -313,24 +299,17 @@ on this account isn't allowed from then the `code` will be set to `EAUTHIP`.
 
 Otherwise the code will be the HTTP response code.
 
-### profile.set(profileData, config) → Promise
+### <a name="set"></a> `> profile.set(profileData, [opts]) → Promise`
 
 ```js
-profile.set({github: 'great-github-account-name'}, {registry, auth: {token}})
+await profile.set({github: 'great-github-account-name'}, {token})
 ```
 
 Update profile information for the authenticated user.
 
 * `profileData` An object, like that returned from `profile.get`, but see
   below for caveats relating to `password`, `tfa` and `cidr_whitelist`.
-* `config` Object
-  * `registry` String (for reference, the npm registry is `https://registry.npmjs.org`)
-  * `auth` Object, properties: `token` — a bearer token returned from
-    `adduser`, `login` or `createToken`, or, `username`, `password` (and
-    optionally `otp`).  Authenticating for this command via a username and
-    password will likely not be supported in the future.
-  * `opts` Object, [make-fetch-happen options](https://www.npmjs.com/package/make-fetch-happen#extra-options) for setting
-    things like cache, proxy, SSL CA and retry rules.
+* [`opts`](#opts) Object (optional)
 
 #### **SETTING `password`**
 
@@ -340,7 +319,12 @@ and `new` properties, where the former has the user's current password and
 the latter has the desired new password. For example
 
 ```js
-profile.set({password: {old: 'abc123', new: 'my new (more secure) password'}}, {registry, auth: {token}})
+await profile.set({
+  password: {
+    old: 'abc123',
+    new: 'my new (more secure) password'
+  }
+}, {token})
 ```
 
 #### **SETTING `cidr_whitelist`**
@@ -350,7 +334,9 @@ Be very careful as it's possible to lock yourself out of your account with
 this.  This is not currently exposed in `npm` itself.
 
 ```js
-profile.set({cidr_whitelist: [ '8.8.8.8/32' ], {registry, auth: {token}})
+await profile.set({
+  cidr_whitelist: [ '8.8.8.8/32' ]
+}, {token})
 // ↑ only one of google's dns servers can now access this account.
 ```
 
@@ -360,7 +346,7 @@ Enabling two-factor authentication is a multi-step process.
 
 1. Call `profile.get` and check the status of `tfa`. If `pending` is true then
    you'll need to disable it with `profile.set({tfa: {password, mode: 'disable'}, …)`.
-2. `profile.set({tfa: {password, mode}}, {registry, auth: {token}})`
+2. `profile.set({tfa: {password, mode}}, {registry, token})`
    * Note that the user's `password` is required here in the `tfa` object,
      regardless of how you're authenticating.
    * `mode` is either `auth-only` which requires an `otp` when calling `login`
@@ -381,7 +367,7 @@ Enabling two-factor authentication is a multi-step process.
    and they can type or copy paste that in.
 4. To complete setting up two factor auth you need to make a second call to
    `profile.set` with `tfa` set to an array of TWO codes from the user's
-   authenticator, eg: `profile.set(tfa: [otp1, otp2]}, registry, {token})`
+   authenticator, eg: `profile.set(tfa: [otp1, otp2]}, {registry, token})`
 5. On success you'll get a result object with a `tfa` property that has an
    array of one-time-use recovery codes.  These are used to authenticate
    later if the second factor is lost and generally should be printed and
@@ -391,7 +377,7 @@ Disabling two-factor authentication is more straightforward, set the `tfa`
 attribute to an object with a `password` property and a `mode` of `disable`.
 
 ```js
-profile.set({tfa: {password, mode: 'disable'}, {registry, auth: {token}}}
+await profile.set({tfa: {password, mode: 'disable'}}, {token})
 ```
 
 #### **Promise Value**
@@ -412,24 +398,16 @@ on this account isn't allowed from then the `code` will be set to `EAUTHIP`.
 
 Otherwise the code will be the HTTP response code.
 
-### profile.listTokens(config) → Promise
+### <a name="list-tokens"></a> `> profile.listTokens([opts]) → Promise`
 
 ```js
-profile.listTokens(registry, {token}).then(tokens => {
-  // do something with tokens
-})
+const tokens = await profile.listTokens({registry, token})
+console.log(`Number of tokens in your accounts: ${tokens.length}`)
 ```
 
 Fetch a list of all of the authentication tokens the authenticated user has.
 
-* `config` Object
-  * `registry` String (for reference, the npm registry is `https://registry.npmjs.org`)
-  * `auth` Object, properties: `token` — a bearer token returned from
-    `adduser`, `login` or `createToken`, or, `username`, `password` (and
-    optionally `otp`).  Authenticating for this command via a username and
-    password will likely not be supported in the future.
-  * `opts` Object, [make-fetch-happen options](https://www.npmjs.com/package/make-fetch-happen#extra-options) for setting
-    things like cache, proxy, SSL CA and retry rules.
+* [`opts`](#opts) Object (optional)
 
 #### **Promise Value**
 
@@ -456,25 +434,17 @@ on this account isn't allowed from then the `code` will be set to `EAUTHIP`.
 
 Otherwise the code will be the HTTP response code.
 
-### profile.removeToken(token|key, config) → Promise
+### <a name="remove-token"><a> `> profile.removeToken(token|key, opts) → Promise`
 
 ```js
-profile.removeToken(key, registry, {token}).then(() => {
-  // token is gone!
-})
+await profile.removeToken(key, {token})
+// token is gone!
 ```
 
 Remove a specific authentication token.
 
 * `token|key` String, either a complete authentication token or the key returned by `profile.listTokens`.
-* `config` Object
-  * `registry` String (for reference, the npm registry is `https://registry.npmjs.org`)
-  * `auth` Object, properties: `token` — a bearer token returned from
-    `adduser`, `login` or `createToken`, or, `username`, `password` (and
-    optionally `otp`).  Authenticating for this command via a username and
-    password will likely not be supported in the future.
-  * `opts` Object, [make-fetch-happen options](https://www.npmjs.com/package/make-fetch-happen#extra-options) for setting
-    things like cache, proxy, SSL CA and retry rules.
+* [`opts`](#opts) Object (optional)
 
 #### **Promise Value**
 
@@ -494,12 +464,13 @@ on this account isn't allowed from then the `code` will be set to `EAUTHIP`.
 
 Otherwise the code will be the HTTP response code.
 
-### profile.createToken(password, readonly, cidr_whitelist, config) → Promise
+### <a name="create-token"></a> `> profile.createToken(password, readonly, cidr_whitelist, [opts]) → Promise`
 
 ```js
-profile.createToken(password, readonly, cidr_whitelist, registry, {token, otp}).then(newToken => {
-  // do something with the newToken
-})
+const newToken = await profile.createToken(
+  password, readonly, cidr_whitelist, {token, otp}
+)
+// do something with the newToken
 ```
 
 Create a new authentication token, possibly with restrictions.
@@ -507,21 +478,14 @@ Create a new authentication token, possibly with restrictions.
 * `password` String
 * `readonly` Boolean
 * `cidr_whitelist` Array
-* `config` Object
-  * `registry` String (for reference, the npm registry is `https://registry.npmjs.org`)
-  * `auth` Object, properties: `token` — a bearer token returned from
-    `adduser`, `login` or `createToken`, or, `username`, `password` (and
-    optionally `otp`).  Authenticating for this command via a username and
-    password will likely not be supported in the future.
-  * `opts` Object, [make-fetch-happen options](https://www.npmjs.com/package/make-fetch-happen#extra-options) for setting
-    things like cache, proxy, SSL CA and retry rules.
+* [`opts`](#opts) Object Optional
 
 #### **Promise Value**
 
 The promise will resolve with an object very much like the one's returned by
 `profile.listTokens`.  The only difference is that `token` is not truncated.
 
-```
+```js
 {
   token: String,
   key: String,    // sha512 hash of the token UUID
@@ -545,12 +509,28 @@ on this account isn't allowed from then the `code` will be set to `EAUTHIP`.
 
 Otherwise the code will be the HTTP response code.
 
-## Logging
+### <a name="opts"></a> options objects
+
+The various API functions accept an optional `opts` object as a final
+argument. This opts object can either be a regular Object, or a
+[`figgy-pudding`](https://npm.im/figgy-pudding) options object instance.
+
+Unless otherwise noted, the options accepted are the same as the
+[`npm-registry-fetch`
+options](https://www.npmjs.com/package/npm-registry-fetch#fetch-opts).
+
+Of particular note are `opts.registry`, and the auth-related options:
+
+* `opts.token` - used for Bearer auth
+* `opts.username` and `opts.password` - used for Basic auth
+* `opts.otp` - the 2fa OTP token
+
+## <a name="logging"></a> Logging
 
 This modules logs by emitting `log` events on the global `process` object.
 These events look like this:
 
-```
+```js
 process.emit('log', 'loglevel', 'feature', 'message part 1', 'part 2', 'part 3', 'etc')
 ```
 
@@ -562,13 +542,13 @@ The remaining arguments are evaluated like `console.log` and joined together wit
 
 A real world example of this is:
 
-```
-  process.emit('log', 'http', 'request', '→',conf.method || 'GET', conf.target)
+```js
+  process.emit('log', 'http', 'request', '→', conf.method || 'GET', conf.target)
 ```
 
 To handle the log events, you would do something like this:
 
-```
+```js
 const log = require('npmlog')
 process.on('log', function (level) {
   return log[level].apply(log, [].slice.call(arguments, 1))

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,6 @@ const fetch = require('npm-registry-fetch')
 const {HttpErrorBase} = require('npm-registry-fetch/errors.js')
 const os = require('os')
 const pudding = require('figgy-pudding')
-const url = require('url')
 const validate = require('aproba')
 
 exports.adduserCouch = adduserCouch

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,8 @@ exports.createToken = createToken
 
 const ProfileConfig = pudding({
   creds: {},
-  hostname: {}
+  hostname: {},
+  otp: {}
 })
 
 // try loginWeb, catch the "not supported" message and fall back to couch
@@ -192,8 +193,11 @@ function loginCouch (username, password, opts) {
       return fetch.json(`${target}/-rev/${body._rev}`, opts.concat({
         method: 'PUT',
         body,
-        username,
-        password
+        forceAuth: {
+          username,
+          password,
+          otp: opts.otp
+        }
       }))
     })
   }).then(result => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,10 @@
 'use strict'
-const fetch = require('make-fetch-happen').defaults({retry: false})
-const validate = require('aproba')
-const url = require('url')
+
+const fetch = require('npm-registry-fetch')
 const os = require('os')
+const pudding = require('figgy-pudding')
+const url = require('url')
+const validate = require('aproba')
 
 exports.adduserCouch = adduserCouch
 exports.loginCouch = loginCouch
@@ -16,9 +18,15 @@ exports.listTokens = listTokens
 exports.removeToken = removeToken
 exports.createToken = createToken
 
+const ProfileConfig = pudding({
+  creds: {},
+  hostname: {}
+})
+
 // try loginWeb, catch the "not supported" message and fall back to couch
 function login (opener, prompter, conf) {
   validate('FFO', arguments)
+  conf = ProfileConfig(conf)
   return loginWeb(opener, conf).catch(er => {
     if (er instanceof WebLoginNotSupported) {
       process.emit('log', 'verbose', 'web login not supported, trying couch')
@@ -32,6 +40,7 @@ function login (opener, prompter, conf) {
 
 function adduser (opener, prompter, conf) {
   validate('FFO', arguments)
+  conf = ProfileConfig(conf)
   return adduserWeb(opener, conf).catch(er => {
     if (er instanceof WebLoginNotSupported) {
       process.emit('log', 'verbose', 'web adduser not supported, trying couch')
@@ -57,55 +66,31 @@ function loginWeb (opener, conf) {
 }
 
 function webAuth (opener, conf, body) {
-  if (!conf.opts) conf.opts = {}
-  const target = url.resolve(conf.registry, '-/v1/login')
+  conf = ProfileConfig(conf)
   body.hostname = conf.hostname || os.hostname()
-  return fetchJSON({
-    target: target,
+  const target = '/-/v1/login'
+  return fetch(target, conf.concat({
     method: 'POST',
-    body: body,
-    opts: conf.opts,
-    saveResponse: true
-  }).then(result => {
-    const res = result[0]
-    const content = result[1]
+    body
+  })).then(res => {
+    return Promise.all([res, res.json()])
+  }).then(([res, content]) => {
+    const {doneUrl, loginUrl} = content
     process.emit('log', 'verbose', 'web auth', 'got response', content)
-    const doneUrl = content.doneUrl
-    const loginUrl = content.loginUrl
-    if (typeof doneUrl !== 'string' ||
-        typeof loginUrl !== 'string' ||
-        !doneUrl || !loginUrl) {
+    if (
+      typeof doneUrl !== 'string' ||
+      typeof loginUrl !== 'string' ||
+      !doneUrl ||
+      !loginUrl
+    ) {
       throw new WebLoginInvalidResponse('POST', target, res, content)
     }
+    return content
+  }).then(({doneUrl, loginUrl}) => {
     process.emit('log', 'verbose', 'web auth', 'opening url pair')
-    const doneConf = {
-      target: doneUrl,
-      method: 'GET',
-      opts: conf.opts,
-      saveResponse: true
-    }
-    return opener(loginUrl).then(() => fetchJSON(doneConf)).then(onDone)
-    function onDone (result) {
-      const res = result[0]
-      const content = result[1]
-      if (res.status === 200) {
-        if (!content.token) {
-          throw new WebLoginInvalidResponse('GET', doneUrl, res, content)
-        } else {
-          return content
-        }
-      } else if (res.status === 202) {
-        const retry = +res.headers.get('retry-after')
-        if (retry > 0) {
-          return new Promise(resolve => setTimeout(resolve, 1000 * retry))
-            .then(() => fetchJSON(doneConf)).then(onDone)
-        } else {
-          return fetchJSON(doneConf).then(onDone)
-        }
-      } else {
-        throw new WebLoginInvalidResponse('GET', doneUrl, res, content)
-      }
-    }
+    return opener(loginUrl).then(
+      () => webAuthCheckLogin(doneUrl, conf.concat({cache: false}))
+    )
   }).catch(er => {
     if ((er.statusCode >= 400 && er.statusCode <= 499) || er.statusCode === 500) {
       throw new WebLoginNotSupported('POST', target, {
@@ -118,10 +103,33 @@ function webAuth (opener, conf, body) {
   })
 }
 
+function webAuthCheckLogin (doneUrl, conf) {
+  return fetch(doneUrl, conf).then(res => {
+    return Promise.all([res, res.json()])
+  }).then(([res, content]) => {
+    if (res.status === 200) {
+      if (!content.token) {
+        throw new WebLoginInvalidResponse('GET', doneUrl, res, content)
+      } else {
+        return content
+      }
+    } else if (res.status === 202) {
+      const retry = +res.headers.get('retry-after') * 1000
+      if (retry > 0) {
+        return sleep(retry).then(() => webAuthCheckLogin(doneUrl, conf))
+      } else {
+        return webAuthCheckLogin(doneUrl, conf)
+      }
+    } else {
+      throw new WebLoginInvalidResponse('GET', doneUrl, res, content)
+    }
+  })
+}
+
 function adduserCouch (username, email, password, conf) {
   validate('SSSO', arguments)
-  if (!conf.opts) conf.opts = {}
-  const userobj = {
+  conf = ProfileConfig(conf)
+  const body = {
     _id: 'org.couchdb.user:' + username,
     name: username,
     password: password,
@@ -131,23 +139,25 @@ function adduserCouch (username, email, password, conf) {
     date: new Date().toISOString()
   }
   const logObj = {}
-  Object.keys(userobj).forEach(k => {
-    logObj[k] = k === 'password' ? 'XXXXX' : userobj[k]
+  Object.keys(body).forEach(k => {
+    logObj[k] = k === 'password' ? 'XXXXX' : body[k]
   })
   process.emit('log', 'verbose', 'adduser', 'before first PUT', logObj)
 
-  const target = url.resolve(conf.registry, '-/user/org.couchdb.user:' + encodeURIComponent(username))
-
-  return fetchJSON({target: target, method: 'PUT', body: userobj, opts: conf.opts})
-    .then(result => {
-      result.username = username
-      return result
-    })
+  const target = '/-/user/org.couchdb.user:' + encodeURIComponent(username)
+  return fetch.json(target, conf.concat({
+    method: 'PUT',
+    body
+  })).then(result => {
+    result.username = username
+    return result
+  })
 }
 
 function loginCouch (username, password, conf) {
   validate('SSO', arguments)
-  const userobj = {
+  conf = ProfileConfig(conf)
+  const body = {
     _id: 'org.couchdb.user:' + username,
     name: username,
     password: password,
@@ -156,36 +166,35 @@ function loginCouch (username, password, conf) {
     date: new Date().toISOString()
   }
   const logObj = {}
-  Object.keys(userobj).forEach(k => {
-    logObj[k] = k === 'password' ? 'XXXXX' : userobj[k]
+  Object.keys(body).forEach(k => {
+    logObj[k] = k === 'password' ? 'XXXXX' : body[k]
   })
   process.emit('log', 'verbose', 'login', 'before first PUT', logObj)
 
-  const target = url.resolve(conf.registry, '-/user/org.couchdb.user:' + encodeURIComponent(username))
-  return fetchJSON(Object.assign({method: 'PUT', target: target, body: userobj}, conf)).catch(err => {
+  const target = '-/user/org.couchdb.user:' + encodeURIComponent(username)
+  return fetch.json(target, conf.concat({
+    method: 'PUT',
+    body
+  })).catch(err => {
     if (err.code === 'E400') {
       err.message = `There is no user with the username "${username}".`
       throw err
     }
     if (err.code !== 'E409') throw err
-    return fetchJSON(Object.assign({method: 'GET', target: target + '?write=true'}, conf)).then(result => {
+    return fetch.json(target, conf.concat({
+      query: {write: true}
+    })).then(result => {
       Object.keys(result).forEach(function (k) {
-        if (!userobj[k] || k === 'roles') {
-          userobj[k] = result[k]
+        if (!body[k] || k === 'roles') {
+          body[k] = result[k]
         }
       })
-      const req = {
+      return fetch.json(`${target}/-rev/${body._rev}`, conf.concat({
         method: 'PUT',
-        target: target + '/-rev/' + userobj._rev,
-        body: userobj,
-        auth: {
-          basic: {
-            username: username,
-            password: password
-          }
-        }
-      }
-      return fetchJSON(Object.assign({}, conf, req))
+        body,
+        username,
+        password
+      }))
     })
   }).then(result => {
     result.username = username
@@ -195,27 +204,29 @@ function loginCouch (username, password, conf) {
 
 function get (conf) {
   validate('O', arguments)
-  const target = url.resolve(conf.registry, '-/npm/v1/user')
-  return fetchJSON(Object.assign({target: target}, conf))
+  return fetch.json('/-/npm/v1/user', conf)
 }
 
 function set (profile, conf) {
   validate('OO', arguments)
-  const target = url.resolve(conf.registry, '-/npm/v1/user')
   Object.keys(profile).forEach(key => {
     // profile keys can't be empty strings, but they CAN be null
     if (profile[key] === '') profile[key] = null
   })
-  return fetchJSON(Object.assign({target: target, method: 'POST', body: profile}, conf))
+  return fetch.json('/-/npm/v1/user', ProfileConfig(conf, {
+    method: 'POST',
+    body: profile
+  }))
 }
 
 function listTokens (conf) {
   validate('O', arguments)
+  conf = ProfileConfig(conf)
 
-  return untilLastPage(`-/npm/v1/tokens`)
+  return untilLastPage('/-/npm/v1/tokens')
 
   function untilLastPage (href, objects) {
-    return fetchJSON(Object.assign({target: url.resolve(conf.registry, href)}, conf)).then(result => {
+    return fetch.json(href, conf).then(result => {
       objects = objects ? objects.concat(result.objects) : result.objects
       if (result.urls.next) {
         return untilLastPage(result.urls.next, objects)
@@ -228,25 +239,25 @@ function listTokens (conf) {
 
 function removeToken (tokenKey, conf) {
   validate('SO', arguments)
-  const target = url.resolve(conf.registry, `-/npm/v1/tokens/token/${tokenKey}`)
-  return fetchJSON(Object.assign({target: target, method: 'DELETE'}, conf))
+  const target = `/-/npm/v1/tokens/token/${tokenKey}`
+  return fetch(target, ProfileConfig(conf, {
+    method: 'DELETE'
+  })).then(res => {
+    res.body.resume()
+    return null
+  })
 }
 
 function createToken (password, readonly, cidrs, conf) {
   validate('SBAO', arguments)
-  const target = url.resolve(conf.registry, '-/npm/v1/tokens')
-  const props = {
-    password: password,
-    readonly: readonly,
-    cidr_whitelist: cidrs
-  }
-  return fetchJSON(Object.assign({target: target, method: 'POST', body: props}, conf))
-}
-
-function FetchError (err, method, target) {
-  err.method = method
-  err.href = target
-  return err
+  return fetch.json('/-/npm/v1/tokens', ProfileConfig(conf, {
+    method: 'POST',
+    body: {
+      password: password,
+      readonly: readonly,
+      cidr_whitelist: cidrs
+    }
+  }))
 }
 
 class HttpErrorBase extends Error {
@@ -256,21 +267,9 @@ class HttpErrorBase extends Error {
     this.statusCode = res.status
     this.code = 'E' + res.status
     this.method = method
-    this.target = target
+    this.target = res.url
     this.body = body
     this.pkgid = packageName(target)
-  }
-}
-
-class HttpErrorGeneral extends HttpErrorBase {
-  constructor (method, target, res, body) {
-    super(method, target, res, body)
-    if (body && body.error) {
-      this.message = `Registry returned ${this.statusCode} for ${this.method} on ${this.target}: ${body.error}`
-    } else {
-      this.message = `Registry returned ${this.statusCode} for ${this.method} on ${this.target}`
-    }
-    Error.captureStackTrace(this, HttpErrorGeneral)
   }
 }
 
@@ -291,104 +290,18 @@ class WebLoginNotSupported extends HttpErrorBase {
   }
 }
 
-class HttpErrorAuthOTP extends HttpErrorBase {
-  constructor (method, target, res, body) {
-    super(method, target, res, body)
-    this.message = 'OTP required for authentication'
-    this.code = 'EOTP'
-    Error.captureStackTrace(this, HttpErrorAuthOTP)
-  }
-}
-
-class HttpErrorAuthIPAddress extends HttpErrorBase {
-  constructor (method, target, res, body) {
-    super(method, target, res, body)
-    this.message = 'Login is not allowed from your IP address'
-    this.code = 'EAUTHIP'
-    Error.captureStackTrace(this, HttpErrorAuthIPAddress)
-  }
-}
-
-class HttpErrorAuthUnknown extends HttpErrorBase {
-  constructor (method, target, res, body) {
-    super(method, target, res, body)
-    this.message = 'Unable to authenticate, need: ' + res.headers.get('www-authenticate')
-    this.code = 'EAUTHUNKNOWN'
-    Error.captureStackTrace(this, HttpErrorAuthUnknown)
-  }
-}
-
-function authHeaders (auth) {
-  const headers = {}
-  if (!auth) return headers
-  if (auth.otp) headers['npm-otp'] = auth.otp
-  if (auth.token) {
-    headers['Authorization'] = 'Bearer ' + auth.token
-  } else if (auth.basic) {
-    const basic = auth.basic.username + ':' + auth.basic.password
-    headers['Authorization'] = 'Basic ' + Buffer.from(basic).toString('base64')
-  }
-  return headers
-}
-
-function fetchJSON (conf) {
-  const fetchOpts = {
-    method: conf.method,
-    headers: Object.assign({}, conf.headers || (conf.auth && authHeaders(conf.auth)) || {})
-  }
-  if (conf.body != null) {
-    fetchOpts.headers['Content-Type'] = 'application/json'
-    fetchOpts.body = JSON.stringify(conf.body)
-  }
-  process.emit('log', 'http', 'request', '→', conf.method || 'GET', conf.target)
-  return fetch.defaults(conf.opts || {})(conf.target, fetchOpts).catch(err => {
-    throw new FetchError(err, conf.method, conf.target)
-  }).then(res => {
-    if (res.headers.has('npm-notice')) {
-      process.emit('warn', 'notice', res.headers.get('npm-notice'))
-    }
-    if (res.headers.get('content-type') === 'application/json') {
-      return res.json().then(content => [res, content])
-    } else {
-      return res.buffer().then(content => {
-        try {
-          return [res, JSON.parse(content)]
-        } catch (_) {
-          return [res, content]
-        }
-      })
-    }
-  }).then(result => {
-    const res = result[0]
-    const content = result[1]
-    const retVal = conf.saveResponse ? result : content
-    process.emit('log', 'http', res.status, `← ${res.statusText} (${conf.target})`)
-    if (res.status === 401 && res.headers.get('www-authenticate')) {
-      const auth = res.headers.get('www-authenticate').split(/,\s*/).map(s => s.toLowerCase())
-      if (auth.indexOf('ipaddress') !== -1) {
-        throw new HttpErrorAuthIPAddress(conf.method, conf.target, res, content)
-      } else if (auth.indexOf('otp') !== -1) {
-        throw new HttpErrorAuthOTP(conf.method, conf.target, res, content)
-      } else {
-        throw new HttpErrorAuthUnknown(conf.method, conf.target, res, content)
-      }
-    } else if (res.status < 200 || res.status >= 300) {
-      throw new HttpErrorGeneral(conf.method, conf.target, res, content)
-    } else {
-      return retVal
-    }
-  })
-}
-
 function packageName (href) {
   try {
     let basePath = url.parse(href).pathname.substr(1)
     if (!basePath.match(/^-/)) {
       basePath = basePath.split('/')
       var index = basePath.indexOf('_rewrite')
+      /* istanbul ignore next */
       if (index === -1) {
         index = basePath.length - 1
       } else {
+        // TODO - I don't even know how we'd hit this but w/e
+        /* istanbul ignore next */
         index++
       }
       return decodeURIComponent(basePath[index])
@@ -396,4 +309,8 @@ function packageName (href) {
   } catch (_) {
     // this is ok
   }
+}
+
+function sleep (ms) {
+  return new Promise((resolve, reject) => setTimeout(resolve, ms))
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -246,11 +246,9 @@ function removeToken (tokenKey, opts) {
   validate('SO', arguments)
   const target = `/-/npm/v1/tokens/token/${tokenKey}`
   return fetch(target, ProfileConfig(opts, {
-    method: 'DELETE'
-  })).then(res => {
-    res.body.resume()
-    return null
-  })
+    method: 'DELETE',
+    ignoreBody: true
+  })).then(() => null)
 }
 
 function createToken (password, readonly, cidrs, opts) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -94,7 +94,7 @@ function webAuth (opener, opts, body) {
     )
   }).catch(er => {
     if ((er.statusCode >= 400 && er.statusCode <= 499) || er.statusCode === 500) {
-      throw new WebLoginNotSupported('POST', target, {
+      throw new WebLoginNotSupported('POST', {
         status: er.statusCode,
         headers: { raw: () => er.headers }
       }, er.body)

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const fetch = require('npm-registry-fetch')
+const {HttpErrorBase} = require('npm-registry-fetch/errors.js')
 const os = require('os')
 const pudding = require('figgy-pudding')
 const url = require('url')
@@ -84,7 +85,7 @@ function webAuth (opener, opts, body) {
       !doneUrl ||
       !loginUrl
     ) {
-      throw new WebLoginInvalidResponse('POST', target, res, content)
+      throw new WebLoginInvalidResponse('POST', res, content)
     }
     return content
   }).then(({doneUrl, loginUrl}) => {
@@ -110,7 +111,7 @@ function webAuthCheckLogin (doneUrl, opts) {
   }).then(([res, content]) => {
     if (res.status === 200) {
       if (!content.token) {
-        throw new WebLoginInvalidResponse('GET', doneUrl, res, content)
+        throw new WebLoginInvalidResponse('GET', res, content)
       } else {
         return content
       }
@@ -122,7 +123,7 @@ function webAuthCheckLogin (doneUrl, opts) {
         return webAuthCheckLogin(doneUrl, opts)
       }
     } else {
-      throw new WebLoginInvalidResponse('GET', doneUrl, res, content)
+      throw new WebLoginInvalidResponse('GET', res, content)
     }
   })
 }
@@ -264,54 +265,20 @@ function createToken (password, readonly, cidrs, opts) {
   }))
 }
 
-class HttpErrorBase extends Error {
-  constructor (method, target, res, body) {
-    super()
-    this.headers = res.headers.raw()
-    this.statusCode = res.status
-    this.code = 'E' + res.status
-    this.method = method
-    this.target = res.url
-    this.body = body
-    this.pkgid = packageName(target)
-  }
-}
-
 class WebLoginInvalidResponse extends HttpErrorBase {
-  constructor (method, target, res, body) {
-    super(method, target, res, body)
+  constructor (method, res, body) {
+    super(method, res, body)
     this.message = 'Invalid response from web login endpoint'
     Error.captureStackTrace(this, WebLoginInvalidResponse)
   }
 }
 
 class WebLoginNotSupported extends HttpErrorBase {
-  constructor (method, target, res, body) {
-    super(method, target, res, body)
+  constructor (method, res, body) {
+    super(method, res, body)
     this.message = 'Web login not supported'
     this.code = 'ENYI'
     Error.captureStackTrace(this, WebLoginNotSupported)
-  }
-}
-
-function packageName (href) {
-  try {
-    let basePath = url.parse(href).pathname.substr(1)
-    if (!basePath.match(/^-/)) {
-      basePath = basePath.split('/')
-      var index = basePath.indexOf('_rewrite')
-      /* istanbul ignore next */
-      if (index === -1) {
-        index = basePath.length - 1
-      } else {
-        // TODO - I don't even know how we'd hit this but w/e
-        /* istanbul ignore next */
-        index++
-      }
-      return decodeURIComponent(basePath[index])
-    }
-  } catch (_) {
-    // this is ok
   }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,52 +24,52 @@ const ProfileConfig = pudding({
 })
 
 // try loginWeb, catch the "not supported" message and fall back to couch
-function login (opener, prompter, conf) {
+function login (opener, prompter, opts) {
   validate('FFO', arguments)
-  conf = ProfileConfig(conf)
-  return loginWeb(opener, conf).catch(er => {
+  opts = ProfileConfig(opts)
+  return loginWeb(opener, opts).catch(er => {
     if (er instanceof WebLoginNotSupported) {
       process.emit('log', 'verbose', 'web login not supported, trying couch')
-      return prompter(conf.creds)
-        .then(data => loginCouch(data.username, data.password, conf))
+      return prompter(opts.creds)
+        .then(data => loginCouch(data.username, data.password, opts))
     } else {
       throw er
     }
   })
 }
 
-function adduser (opener, prompter, conf) {
+function adduser (opener, prompter, opts) {
   validate('FFO', arguments)
-  conf = ProfileConfig(conf)
-  return adduserWeb(opener, conf).catch(er => {
+  opts = ProfileConfig(opts)
+  return adduserWeb(opener, opts).catch(er => {
     if (er instanceof WebLoginNotSupported) {
       process.emit('log', 'verbose', 'web adduser not supported, trying couch')
-      return prompter(conf.creds)
-        .then(data => adduserCouch(data.username, data.email, data.password, conf))
+      return prompter(opts.creds)
+        .then(data => adduserCouch(data.username, data.email, data.password, opts))
     } else {
       throw er
     }
   })
 }
 
-function adduserWeb (opener, conf) {
+function adduserWeb (opener, opts) {
   validate('FO', arguments)
   const body = { create: true }
   process.emit('log', 'verbose', 'web adduser', 'before first POST')
-  return webAuth(opener, conf, body)
+  return webAuth(opener, opts, body)
 }
 
-function loginWeb (opener, conf) {
+function loginWeb (opener, opts) {
   validate('FO', arguments)
   process.emit('log', 'verbose', 'web login', 'before first POST')
-  return webAuth(opener, conf, {})
+  return webAuth(opener, opts, {})
 }
 
-function webAuth (opener, conf, body) {
-  conf = ProfileConfig(conf)
-  body.hostname = conf.hostname || os.hostname()
+function webAuth (opener, opts, body) {
+  opts = ProfileConfig(opts)
+  body.hostname = opts.hostname || os.hostname()
   const target = '/-/v1/login'
-  return fetch(target, conf.concat({
+  return fetch(target, opts.concat({
     method: 'POST',
     body
   })).then(res => {
@@ -89,7 +89,7 @@ function webAuth (opener, conf, body) {
   }).then(({doneUrl, loginUrl}) => {
     process.emit('log', 'verbose', 'web auth', 'opening url pair')
     return opener(loginUrl).then(
-      () => webAuthCheckLogin(doneUrl, conf.concat({cache: false}))
+      () => webAuthCheckLogin(doneUrl, opts.concat({cache: false}))
     )
   }).catch(er => {
     if ((er.statusCode >= 400 && er.statusCode <= 499) || er.statusCode === 500) {
@@ -103,8 +103,8 @@ function webAuth (opener, conf, body) {
   })
 }
 
-function webAuthCheckLogin (doneUrl, conf) {
-  return fetch(doneUrl, conf).then(res => {
+function webAuthCheckLogin (doneUrl, opts) {
+  return fetch(doneUrl, opts).then(res => {
     return Promise.all([res, res.json()])
   }).then(([res, content]) => {
     if (res.status === 200) {
@@ -116,9 +116,9 @@ function webAuthCheckLogin (doneUrl, conf) {
     } else if (res.status === 202) {
       const retry = +res.headers.get('retry-after') * 1000
       if (retry > 0) {
-        return sleep(retry).then(() => webAuthCheckLogin(doneUrl, conf))
+        return sleep(retry).then(() => webAuthCheckLogin(doneUrl, opts))
       } else {
-        return webAuthCheckLogin(doneUrl, conf)
+        return webAuthCheckLogin(doneUrl, opts)
       }
     } else {
       throw new WebLoginInvalidResponse('GET', doneUrl, res, content)
@@ -126,9 +126,9 @@ function webAuthCheckLogin (doneUrl, conf) {
   })
 }
 
-function adduserCouch (username, email, password, conf) {
+function adduserCouch (username, email, password, opts) {
   validate('SSSO', arguments)
-  conf = ProfileConfig(conf)
+  opts = ProfileConfig(opts)
   const body = {
     _id: 'org.couchdb.user:' + username,
     name: username,
@@ -145,7 +145,7 @@ function adduserCouch (username, email, password, conf) {
   process.emit('log', 'verbose', 'adduser', 'before first PUT', logObj)
 
   const target = '/-/user/org.couchdb.user:' + encodeURIComponent(username)
-  return fetch.json(target, conf.concat({
+  return fetch.json(target, opts.concat({
     method: 'PUT',
     body
   })).then(result => {
@@ -154,9 +154,9 @@ function adduserCouch (username, email, password, conf) {
   })
 }
 
-function loginCouch (username, password, conf) {
+function loginCouch (username, password, opts) {
   validate('SSO', arguments)
-  conf = ProfileConfig(conf)
+  opts = ProfileConfig(opts)
   const body = {
     _id: 'org.couchdb.user:' + username,
     name: username,
@@ -172,7 +172,7 @@ function loginCouch (username, password, conf) {
   process.emit('log', 'verbose', 'login', 'before first PUT', logObj)
 
   const target = '-/user/org.couchdb.user:' + encodeURIComponent(username)
-  return fetch.json(target, conf.concat({
+  return fetch.json(target, opts.concat({
     method: 'PUT',
     body
   })).catch(err => {
@@ -181,7 +181,7 @@ function loginCouch (username, password, conf) {
       throw err
     }
     if (err.code !== 'E409') throw err
-    return fetch.json(target, conf.concat({
+    return fetch.json(target, opts.concat({
       query: {write: true}
     })).then(result => {
       Object.keys(result).forEach(function (k) {
@@ -189,7 +189,7 @@ function loginCouch (username, password, conf) {
           body[k] = result[k]
         }
       })
-      return fetch.json(`${target}/-rev/${body._rev}`, conf.concat({
+      return fetch.json(`${target}/-rev/${body._rev}`, opts.concat({
         method: 'PUT',
         body,
         username,
@@ -202,31 +202,31 @@ function loginCouch (username, password, conf) {
   })
 }
 
-function get (conf) {
+function get (opts) {
   validate('O', arguments)
-  return fetch.json('/-/npm/v1/user', conf)
+  return fetch.json('/-/npm/v1/user', opts)
 }
 
-function set (profile, conf) {
+function set (profile, opts) {
   validate('OO', arguments)
   Object.keys(profile).forEach(key => {
     // profile keys can't be empty strings, but they CAN be null
     if (profile[key] === '') profile[key] = null
   })
-  return fetch.json('/-/npm/v1/user', ProfileConfig(conf, {
+  return fetch.json('/-/npm/v1/user', ProfileConfig(opts, {
     method: 'POST',
     body: profile
   }))
 }
 
-function listTokens (conf) {
+function listTokens (opts) {
   validate('O', arguments)
-  conf = ProfileConfig(conf)
+  opts = ProfileConfig(opts)
 
   return untilLastPage('/-/npm/v1/tokens')
 
   function untilLastPage (href, objects) {
-    return fetch.json(href, conf).then(result => {
+    return fetch.json(href, opts).then(result => {
       objects = objects ? objects.concat(result.objects) : result.objects
       if (result.urls.next) {
         return untilLastPage(result.urls.next, objects)
@@ -237,10 +237,10 @@ function listTokens (conf) {
   }
 }
 
-function removeToken (tokenKey, conf) {
+function removeToken (tokenKey, opts) {
   validate('SO', arguments)
   const target = `/-/npm/v1/tokens/token/${tokenKey}`
-  return fetch(target, ProfileConfig(conf, {
+  return fetch(target, ProfileConfig(opts, {
     method: 'DELETE'
   })).then(res => {
     res.body.resume()
@@ -248,9 +248,9 @@ function removeToken (tokenKey, conf) {
   })
 }
 
-function createToken (password, readonly, cidrs, conf) {
+function createToken (password, readonly, cidrs, opts) {
   validate('SBAO', arguments)
-  return fetch.json('/-/npm/v1/tokens', ProfileConfig(conf, {
+  return fetch.json('/-/npm/v1/tokens', ProfileConfig(opts, {
     method: 'POST',
     body: {
       password: password,

--- a/lib/package.json
+++ b/lib/package.json
@@ -7,7 +7,8 @@
   "license": "ISC",
   "dependencies": {
     "aproba": "^1.1.2 || 2",
-    "make-fetch-happen": "^2.5.0 || 3 || 4"
+    "figgy-pudding": "^3.4.1",
+    "npm-registry-fetch": "^3.3.0"
   },
   "main": "index.js",
   "repository": {

--- a/lib/test/index.js
+++ b/lib/test/index.js
@@ -1,119 +1,161 @@
 'use strict'
+
 const test = require('tap').test
-const requireInject = require('require-inject')
+const tnock = require('./util/tnock.js')
 
-function promise$try (fn) {
-  return new Promise(resolve => {
-    resolve(fn())
-  })
-}
+const profile = require('../index.js')
 
-function mockFetch (mocks) {
-  const fn = function (href, opts) {
-    const mockf = mocks[href]
-    const method = (opts && opts.method) || 'GET'
-    const mock = mockf && mockf(method, opts)
-    if (!mock) {
-      return mockFetchResponse(404, 'not found:' + href, {}, '')
-    }
-    return mockFetchResponse(mock.status, mock.statusText, mock.headers, mock.body)
-  }
-  fn.defaults = setDefaults
-  return fn
-
-  function setDefaults (moreOpts) {
-    const fn = (href, opts) => {
-      return this.call(this, href, Object.assign({}, opts || {}, moreOpts))
-    }
-    fn.defaults = setDefaults
-    return fn
-  }
-}
-
-function mockFetchResponse (status, statusText, headers, body) {
-  if (body == null) {
-    body = headers
-    headers = {}
-  }
-  return Promise.resolve({
-    status: status,
-    statusText: statusText,
-    headers: {
-      get (header) {
-        return headers[header]
-      },
-      has (header) {
-        return header in headers
-      },
-      raw () {
-        return headers
-      }
-    },
-    buffer () {
-      if (Buffer.isBuffer(body)) {
-        return Promise.resolve(body)
-      } else if (typeof body === 'string') {
-        return Promise.resolve(Buffer.from(body))
-      } else if (typeof body === 'object') {
-        return Promise.resolve(Buffer.from(JSON.stringify(body)))
-      } else {
-        return Promise.reject(new Error('Unknown body type: ' + typeof body))
-      }
-    },
-    json () {
-      return this.buffer().then(body => JSON.parse(body))
-    }
-  })
-}
-
-// make sure it's in the cache before require-inject is called, because its
-// combination of deferred loading and instanceof checks makes things go
-// bad.
-require('readable-stream')
+const registry = 'https://my.registry.tech/'
 
 test('get', t => {
-  const profile = requireInject.withEmptyCache('../index.js', {
-    'make-fetch-happen': mockFetch({
-      '/-/npm/v1/user': (method, opts) => {
-        if (method !== 'GET') return {status: 400, statusText: 'error', headers: {}, body: ''}
-        if (!opts.headers) return {status: 401, statusText: 'no headers', headers: {}, body: ''}
-        if (!opts.headers['Authorization']) return {status: 401, statusText: 'unauthorized', headers: {}, body: ''}
-        const body = {ok: true}
-        if (opts.headers['npm-otp']) body.otp = true
-        if (/Bearer/.test(opts.headers['Authorization'])) body.auth = 'bearer'
-        if (/Basic/.test(opts.headers['Authorization'])) body.auth = 'basic'
-        return {
-          status: 200,
-          statsText: 'ok',
-          headers: {},
-          body: body
-        }
-      }
-    })
+  const srv = tnock(t, registry)
+  const getUrl = '/-/npm/v1/user'
+  srv.get(getUrl).reply(function () {
+    const auth = this.req.headers['authorization']
+    t.notOk(auth, 'no authorization info sent')
+    return [auth ? 200 : 401, '', {}]
   })
-  return promise$try(() => {
-    return profile.get({registry: '/'})
-  }).then(result => {
+  return profile.get({registry}).then(result => {
     t.fail('GET w/o auth should fail')
   }, err => {
     t.is(err.code, 'E401', 'auth errors are passed through')
   }).then(() => {
-    return profile.get({registry: '/', auth: {token: 'deadbeef'}})
+    srv.get(getUrl).reply(function () {
+      const auth = this.req.headers['authorization']
+      t.deepEqual(auth, ['Bearer deadbeef'], 'got auth header')
+      return [auth ? 200 : 401, {auth: 'bearer'}, {}]
+    })
+    return profile.get({registry, token: 'deadbeef'})
   }).then(result => {
     t.like(result, {auth: 'bearer'})
   }).then(() => {
-    return profile.get({registry: '/', auth: {basic: {username: 'abc', password: '123'}}})
+    srv.get(getUrl).reply(function () {
+      const auth = this.req.headers['authorization']
+      t.match(auth[0], /^Basic /, 'got basic auth')
+      const [username, password] = Buffer.from(
+        auth[0].match(/^Basic (.*)$/)[1], 'base64'
+      ).toString('utf8').split(':')
+      t.equal(username, 'abc', 'got username')
+      t.equal(password, '123', 'got password')
+      return [auth ? 200 : 401, {auth: 'basic'}, {}]
+    })
+    return profile.get({
+      registry,
+      username: 'abc',
+      // Passwords are stored in base64 form and npm-related consumers expect
+      // them in this format. Changing this for npm would be a bigger change.
+      password: Buffer.from('123', 'utf8').toString('base64')
+    })
   }).then(result => {
     t.like(result, {auth: 'basic'})
   }).then(() => {
-    return profile.get({registry: '/', auth: {otp: '1234', token: 'deadbeef'}})
+    srv.get(getUrl).reply(function () {
+      const auth = this.req.headers['authorization']
+      const otp = this.req.headers['npm-otp']
+      t.deepEqual(auth, ['Bearer deadbeef'], 'got auth header')
+      t.deepequal(otp, ['1234'], 'got otp token')
+      return [auth ? 200 : 401, {auth: 'bearer', otp: !!otp}, {}]
+    })
+    return profile.get({registry, otp: '1234', token: 'deadbeef'})
   }).then(result => {
     t.like(result, {auth: 'bearer', otp: true})
   })
   // with otp, with token, with basic
   // prob should make w/o token 401
 })
-test('set')
-test('listTokens')
-test('removeToken')
-test('createToken')
+
+test('set', t => {
+  const prof = {user: 'zkat', github: 'zkat'}
+  tnock(t, registry).post('/-/npm/v1/user', {
+    github: 'zkat',
+    email: null
+  }).reply(200, prof)
+  return profile.set({
+    github: 'zkat',
+    email: ''
+  }, {registry}).then(json => {
+    t.deepEqual(json, prof, 'got the profile data in return')
+  })
+})
+
+test('listTokens', t => {
+  const tokens = [
+    {key: 'sha512-hahaha', token: 'blah'},
+    {key: 'sha512-meh', token: 'bleh'}
+  ]
+  tnock(t, registry).get('/-/npm/v1/tokens').reply(200, {
+    objects: tokens,
+    total: 2,
+    urls: {}
+  })
+  return profile.listTokens({registry}).then(tok => t.deepEqual(tok, tokens))
+})
+
+test('listTokens multipage', t => {
+  const tokens1 = [
+    {key: 'sha512-hahaha', token: 'blah'},
+    {key: 'sha512-meh', token: 'bleh'}
+  ]
+  const tokens2 = [
+    {key: 'sha512-ugh', token: 'blih'},
+    {key: 'sha512-ohno', token: 'bloh'}
+  ]
+  const tokens3 = [
+    {key: 'sha512-stahp', token: 'bluh'}
+  ]
+  const srv = tnock(t, registry)
+  srv.get('/-/npm/v1/tokens').reply(200, {
+    objects: tokens1,
+    total: 2,
+    urls: {
+      next: '/idk/some/other/one'
+    }
+  })
+  srv.get('/idk/some/other/one').reply(200, {
+    objects: tokens2,
+    total: 2,
+    urls: {
+      next: '/-/npm/last/one-i-swear'
+    }
+  })
+  srv.get('/-/npm/last/one-i-swear').reply(200, {
+    objects: tokens3,
+    total: 1,
+    urls: {}
+  })
+  return profile.listTokens({registry}).then(tok => {
+    t.deepEqual(
+      tok,
+      tokens1.concat(tokens2).concat(tokens3),
+      'supports multi-URL token requests and concats them'
+    )
+  })
+})
+
+test('removeToken', t => {
+  tnock(t, registry).delete('/-/npm/v1/tokens/token/deadbeef').reply(200)
+  return profile.removeToken('deadbeef', {registry}).then(ret => {
+    t.equal(ret, null, 'null return value on success')
+  })
+})
+
+test('createToken', t => {
+  const base = {
+    password: 'secretPassw0rd!',
+    readonly: true,
+    cidr_whitelist: ['8.8.8.8/32', '127.0.0.1', '192.168.1.1']
+  }
+  const obj = Object.assign({
+    token: 'deadbeef',
+    key: 'sha512-badc0ffee',
+    created: (new Date()).toString()
+  })
+  delete obj.password
+  tnock(t, registry).post('/-/npm/v1/tokens', base).reply(200, obj)
+  return profile.createToken(
+    base.password,
+    base.readonly,
+    base.cidr_whitelist,
+    {registry}
+  ).then(ret => t.deepEqual(ret, obj, 'got the right return value'))
+})

--- a/lib/test/login.js
+++ b/lib/test/login.js
@@ -391,7 +391,7 @@ t.test('fail at login step', t => {
     statusCode: 200,
     code: 'E200',
     method: 'POST',
-    target: reg + '/invalid-login/-/v1/login',
+    uri: reg + '/invalid-login/-/v1/login',
     body: {
       salt: 'im helping'
     },
@@ -410,7 +410,7 @@ t.test('fail at the done step', t => {
     statusCode: 299,
     code: 'E299',
     method: 'GET',
-    target: reg + '/invalid-done/-/v1/login/blerg',
+    uri: reg + '/invalid-done/-/v1/login/blerg',
     body: {
       salt: 'im helping'
     },
@@ -430,7 +430,7 @@ t.test('notoken response from login endpoint (status 200, bad data)', t => {
     code: 'E200',
     statusCode: 200,
     method: 'GET',
-    target: registry + '-/v1/login/blerg',
+    uri: registry + '-/v1/login/blerg',
     body: {
       oh: 'no'
     },

--- a/lib/test/util/tnock.js
+++ b/lib/test/util/tnock.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const nock = require('nock')
+
+module.exports = tnock
+function tnock (t, host) {
+  const server = nock(host)
+  t.tearDown(function () {
+    server.done()
+  })
+  return server
+}

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "acorn": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.6.2.tgz",
-      "integrity": "sha512-zUzo1E5dI2Ey8+82egfnttyMlMZ2y0D8xOCO3PNPPlYXpl8NZvF6Qk9L9BEtJs+43FqEmfBViDqc5d1ckRDguw==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
+      "integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ==",
       "dev": true
     },
     "acorn-jsx": {
@@ -28,17 +28,17 @@
       }
     },
     "agent-base": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
-      "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
       "requires": {
         "es6-promisify": "^5.0.0"
       }
     },
     "agentkeepalive": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.4.1.tgz",
-      "integrity": "sha512-MPIwsZU9PP9kOrZpyu2042kYA8Fdt/AedQYkYXucHgF9QoD9dXVp0ypuGnHXSR0hTstBxdt85Xkh4JolYfK5wg==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.5.1.tgz",
+      "integrity": "sha512-Cte/sTY9/XcygXjJ0q58v//SnEQ7ViWExKyJpLJlLqomDbQyMLh6Is4KuWJ/wmxzhiwkGRple7Gqv1zf6Syz5w==",
       "requires": {
         "humanize-ms": "^1.2.1"
       }
@@ -68,9 +68,9 @@
       "dev": true
     },
     "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
     },
     "ansi-styles": {
       "version": "2.2.1",
@@ -132,22 +132,25 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-      "dev": true
-    },
     "asn1": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-      "dev": true
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
     },
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
+    },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
     "asynckit": {
@@ -163,9 +166,9 @@
       "dev": true
     },
     "aws4": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
     },
     "babel-code-frame": {
@@ -179,6 +182,12 @@
         "js-tokens": "^3.0.2"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -191,6 +200,15 @@
             "strip-ansi": "^3.0.0",
             "supports-color": "^2.0.0"
           }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
         }
       }
     },
@@ -200,9 +218,9 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "optional": true,
       "requires": {
@@ -230,9 +248,9 @@
       }
     },
     "buffer-from": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
-      "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -240,17 +258,22 @@
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
+    "builtins": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+      "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og="
+    },
     "cacache": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.0.2.tgz",
-      "integrity": "sha512-hMiz7LN4w8sdfmKsvNs80ao/vf2JCGWWdpu95JyY90AJZRbZJmgE71dCefRiNf8OCqiZQDcUBfYiLlUNu4/j5A==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.2.0.tgz",
+      "integrity": "sha512-IFWl6lfK6wSeYCHUXh+N1lY72UDrpyrYQJNIVQf48paDuWbv5RbAtJYf/4gUQFObTCHZwdZ5sI8Iw7nqwP6nlQ==",
       "requires": {
         "bluebird": "^3.5.1",
         "chownr": "^1.0.1",
         "figgy-pudding": "^3.1.0",
         "glob": "^7.1.2",
         "graceful-fs": "^4.1.11",
-        "lru-cache": "^4.1.2",
+        "lru-cache": "^4.1.3",
         "mississippi": "^3.0.0",
         "mkdirp": "^0.5.1",
         "move-concurrently": "^1.0.1",
@@ -259,27 +282,6 @@
         "ssri": "^6.0.0",
         "unique-filename": "^1.1.0",
         "y18n": "^4.0.0"
-      },
-      "dependencies": {
-        "bluebird": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
-        },
-        "lru-cache": {
-          "version": "4.1.3",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-          "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
-          "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
-          }
-        },
-        "y18n": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
-        }
       }
     },
     "caller": {
@@ -314,6 +316,20 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
+    "chai": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
+      "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.0.1",
+        "check-error": "^1.0.1",
+        "deep-eql": "^3.0.0",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.0.0",
+        "type-detect": "^4.0.0"
+      }
+    },
     "chalk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
@@ -335,9 +351,9 @@
           }
         },
         "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -351,15 +367,24 @@
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
       "dev": true
     },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
+    },
     "chownr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
       "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
     },
     "cidr-regex": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cidr-regex/-/cidr-regex-1.0.6.tgz",
-      "integrity": "sha1-dKv9YZ3zcLnVSrFEdVaOl91kwME="
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/cidr-regex/-/cidr-regex-2.0.9.tgz",
+      "integrity": "sha512-F7/fBRUU45FnvSPjXdpIrc++WRSBdCiSTlyq4ZNhLKOlHFNWgtzZ0Fd+zrqI/J1j0wmlx/f5ZQDmD2GcbrNcmw==",
+      "requires": {
+        "ip-regex": "^2.1.0"
+      }
     },
     "circular-json": {
       "version": "0.3.3",
@@ -396,35 +421,6 @@
         "string-width": "^2.1.1",
         "strip-ansi": "^4.0.0",
         "wrap-ansi": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
       }
     },
     "co": {
@@ -439,18 +435,18 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "color-convert": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
+      "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
       "dev": true,
       "requires": {
-        "color-name": "^1.1.1"
+        "color-name": "1.1.1"
       }
     },
     "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok=",
       "dev": true
     },
     "color-support": {
@@ -515,28 +511,23 @@
         }
       }
     },
-    "core-js": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
-      "dev": true
-    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "coveralls": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.1.tgz",
-      "integrity": "sha512-FAzXwiDOYLGDWH+zgoIA+8GbWv50hlx+kpEJyvzLKOdnIBv9uWoVl4DhqGgyUHpiRjAlF8KYZSipWXYtllWH6Q==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.2.tgz",
+      "integrity": "sha512-Tv0LKe/MkBOilH2v7WBiTBdudg2ChfGbdXafc/s330djpF3zKOmuehTeRwjXWc7pzfj9FrDUTA7tEx6Div8NFw==",
       "dev": true,
       "requires": {
-        "js-yaml": "^3.6.1",
+        "growl": "~> 1.10.0",
+        "js-yaml": "^3.11.0",
         "lcov-parse": "^0.0.10",
-        "log-driver": "^1.2.5",
+        "log-driver": "^1.2.7",
         "minimist": "^1.2.0",
-        "request": "^2.79.0"
+        "request": "^2.85.0"
       },
       "dependencies": {
         "minimist": {
@@ -548,12 +539,12 @@
       }
     },
     "cross-spawn": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-      "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
-      "dev": true,
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "requires": {
         "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       }
     },
@@ -577,13 +568,6 @@
       "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "requires": {
         "ms": "2.0.0"
-      },
-      "dependencies": {
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
       }
     },
     "debug-log": {
@@ -593,14 +577,32 @@
       "dev": true
     },
     "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
+      "integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
+      "requires": {
+        "xregexp": "4.0.0"
+      }
     },
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
     },
     "deep-is": {
       "version": "0.1.3",
@@ -609,19 +611,18 @@
       "dev": true
     },
     "define-properties": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "dev": true,
       "requires": {
-        "foreach": "^2.0.5",
-        "object-keys": "^1.0.8"
+        "object-keys": "^1.0.12"
       }
     },
     "deglob": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/deglob/-/deglob-2.1.0.tgz",
-      "integrity": "sha1-TUSr4W7zLHebSXK9FBqAMlApoUo=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/deglob/-/deglob-2.1.1.tgz",
+      "integrity": "sha512-2kjwuGGonL7gWE1XU4Fv79+vVzpoQCl0V+boMwWtOQJV2AGDabCwez++nB1Nli/8BabAfZQ/UuHPlp6AymKdWw==",
       "dev": true,
       "requires": {
         "find-root": "^1.0.0",
@@ -685,13 +686,14 @@
       }
     },
     "ecc-jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "~0.1.0"
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "encoding": {
@@ -716,9 +718,9 @@
       "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
     },
     "error-ex": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
@@ -810,34 +812,6 @@
         "strip-json-comments": "~2.0.1",
         "table": "4.0.2",
         "text-table": "~0.2.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
       }
     },
     "eslint-config-standard": {
@@ -870,12 +844,6 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
         }
       }
     },
@@ -897,12 +865,6 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
         }
       }
     },
@@ -942,12 +904,6 @@
             "esutils": "^2.0.2",
             "isarray": "^1.0.0"
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
         }
       }
     },
@@ -961,14 +917,6 @@
         "minimatch": "^3.0.4",
         "resolve": "^1.3.3",
         "semver": "^5.4.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-          "dev": true
-        }
       }
     },
     "eslint-plugin-promise": {
@@ -996,9 +944,9 @@
       "dev": true
     },
     "eslint-scope": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
-      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
+      "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
       "dev": true,
       "requires": {
         "esrecurse": "^4.1.0",
@@ -1022,9 +970,9 @@
       }
     },
     "esprima": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
     "esquery": {
@@ -1075,24 +1023,12 @@
         "p-finally": "^1.0.0",
         "signal-exit": "^3.0.0",
         "strip-eof": "^1.0.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        }
       }
     },
     "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true
     },
     "external-editor": {
@@ -1130,25 +1066,10 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
-    "fbjs": {
-      "version": "0.8.16",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
-      "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
-      "dev": true,
-      "requires": {
-        "core-js": "^1.0.0",
-        "isomorphic-fetch": "^2.1.1",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.9"
-      }
-    },
     "figgy-pudding": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.1.0.tgz",
-      "integrity": "sha512-Gi2vIue0ec6P/7LNpueGhLuvfF2ztuterl8YFBQn1yKgIS46noGxCbi+vviPdObNYtgUSh5FpHy5q0Cw9XhxKQ=="
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.4.1.tgz",
+      "integrity": "sha512-j1SAT641cerGuOvoSBoaE9LbSzh1N/E5ufk9oMpOKuyK8MyW3sGg4rh+4qhLmVTEAzipO5XTHYT4gjb6JYLE8g=="
     },
     "figures": {
       "version": "2.0.0",
@@ -1176,11 +1097,11 @@
       "dev": true
     },
     "find-up": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
       "requires": {
-        "locate-path": "^2.0.0"
+        "locate-path": "^3.0.0"
       }
     },
     "flat-cache": {
@@ -1204,12 +1125,6 @@
         "readable-stream": "^2.0.4"
       }
     },
-    "foreach": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
-      "dev": true
-    },
     "foreground-child": {
       "version": "1.5.6",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
@@ -1218,6 +1133,18 @@
       "requires": {
         "cross-spawn": "^4",
         "signal-exit": "^3.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
+          }
+        }
       }
     },
     "forever-agent": {
@@ -1301,10 +1228,23 @@
         "wide-align": "^1.1.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
         "aproba": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
         },
         "string-width": {
           "version": "1.0.2",
@@ -1315,13 +1255,27 @@
             "is-fullwidth-code-point": "^1.0.0",
             "strip-ansi": "^3.0.0"
           }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
         }
       }
     },
     "get-caller-file": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
     },
     "get-stdin": {
       "version": "6.0.0",
@@ -1357,9 +1311,9 @@
       }
     },
     "globals": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.5.0.tgz",
-      "integrity": "sha512-hYyf+kI8dm3nORsiiXUQigOU62hDLfJ9G01uyGMxhc6BKsircrUhC4uJPQPUSuq2GrTmiiEt7ewxlMdBewfmKQ==",
+      "version": "11.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
+      "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
       "dev": true
     },
     "globby": {
@@ -1381,6 +1335,12 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
+    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -1388,12 +1348,12 @@
       "dev": true
     },
     "har-validator": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
+      "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
       "dev": true,
       "requires": {
-        "ajv": "^5.1.0",
+        "ajv": "^5.3.0",
         "har-schema": "^2.0.0"
       }
     },
@@ -1413,6 +1373,14 @@
       "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        }
       }
     },
     "has-flag": {
@@ -1427,10 +1395,9 @@
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
     "hosted-git-info": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
-      "dev": true
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
     },
     "http-cache-semantics": {
       "version": "3.8.1",
@@ -1488,9 +1455,9 @@
       "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
     },
     "ignore": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.8.tgz",
-      "integrity": "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg==",
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
       "dev": true
     },
     "imurmurhash": {
@@ -1537,23 +1504,6 @@
         "string-width": "^2.1.0",
         "strip-ansi": "^4.0.0",
         "through": "^2.3.6"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
       }
     },
     "invert-kv": {
@@ -1565,6 +1515,11 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+    },
+    "ip-regex": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -1582,17 +1537,17 @@
       }
     },
     "is-callable": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
       "dev": true
     },
     "is-cidr": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-cidr/-/is-cidr-1.0.0.tgz",
-      "integrity": "sha1-+1qs9lklUxA1naMsrgPkDGocKvw=",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/is-cidr/-/is-cidr-2.0.6.tgz",
+      "integrity": "sha512-A578p1dV22TgPXn6NCaDAPj6vJvYsBgAzUrAd28a4oldeXJjWqEUuSZOLIW3im51mazOKsoyVp8NU/OItlWacw==",
       "requires": {
-        "cidr-regex": "1.0.6"
+        "cidr-regex": "^2.0.8"
       }
     },
     "is-date-object": {
@@ -1602,12 +1557,9 @@
       "dev": true
     },
     "is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "requires": {
-        "number-is-nan": "^1.0.0"
-      }
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -1680,16 +1632,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-    },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "dev": true,
-      "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -1807,11 +1749,11 @@
       }
     },
     "locate-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
       "requires": {
-        "p-locate": "^2.0.0",
+        "p-locate": "^3.0.0",
         "path-exists": "^3.0.0"
       }
     },
@@ -1828,18 +1770,18 @@
       "dev": true
     },
     "loose-envify": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "requires": {
-        "js-tokens": "^3.0.0"
+        "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
     "lru-cache": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
       "requires": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
@@ -1861,17 +1803,6 @@
         "promise-retry": "^1.1.1",
         "socks-proxy-agent": "^4.0.0",
         "ssri": "^6.0.0"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "4.1.3",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-          "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
-          "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
-          }
-        }
       }
     },
     "mem": {
@@ -1883,24 +1814,24 @@
       }
     },
     "mime-db": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+      "version": "1.35.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
+      "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.18",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "version": "2.1.19",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
+      "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
       "dev": true,
       "requires": {
-        "mime-db": "~1.33.0"
+        "mime-db": "~1.35.0"
       }
     },
     "mimic-fn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -1916,21 +1847,15 @@
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "minipass": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.3.tgz",
-      "integrity": "sha512-/jAn9/tEX4gnpyRATxgHEOV6xbcyxgT7iUnxo9Y3+OB0zX00TgKIv/2FZCf5brBbICcwbLqVv2ImjvWWrQMSYw==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.4.tgz",
+      "integrity": "sha512-mlouk1OHlaUE8Odt1drMtG1bAJA4ZA6B/ehysgV0LUIrDHdKgo1KorZq3pK0b/7Z7LJIQ12MNM6aC+Tn6lUZ5w==",
       "dev": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
       },
       "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
-        },
         "yallist": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
@@ -1985,9 +1910,9 @@
       }
     },
     "ms": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -2000,14 +1925,21 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
-    "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+    "nock": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-9.6.1.tgz",
+      "integrity": "sha512-EDgl/WgNQ0C1BZZlASOQkQdE6tAWXJi8QQlugqzN64JJkvZ7ILijZuG24r4vCC7yOfnm6HKpne5AGExLGCeBWg==",
       "dev": true,
       "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
+        "chai": "^4.1.2",
+        "debug": "^3.1.0",
+        "deep-equal": "^1.0.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.5",
+        "mkdirp": "^0.5.0",
+        "propagate": "^1.0.0",
+        "qs": "^6.5.1",
+        "semver": "^5.5.0"
       }
     },
     "node-fetch-npm": {
@@ -2030,6 +1962,29 @@
         "is-builtin-module": "^1.0.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "npm-package-arg": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.0.tgz",
+      "integrity": "sha512-zYbhP2k9DbJhA0Z3HKUePUgdB1x7MfIfKssC+WLPFMKTBZKpZh5m13PgexJjCq6KW7j17r0jHWcCpxEqnnncSA==",
+      "requires": {
+        "hosted-git-info": "^2.6.0",
+        "osenv": "^0.1.5",
+        "semver": "^5.5.0",
+        "validate-npm-package-name": "^3.0.0"
+      }
+    },
+    "npm-registry-fetch": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-3.3.0.tgz",
+      "integrity": "sha512-LlJnM1BR3X9WxcJksur4+tSmo6RpXd3gdjQUQpkI/u8pKGP/kSbCV7XWE5DVgHslCiq5GBVonDqmutrCntIu3Q==",
+      "requires": {
+        "bluebird": "^3.5.1",
+        "figgy-pudding": "^3.2.0",
+        "lru-cache": "^4.1.3",
+        "make-fetch-happen": "^4.0.1",
+        "npm-package-arg": "^6.1.0"
       }
     },
     "npm-run-path": {
@@ -4692,9 +4647,9 @@
       }
     },
     "oauth-sign": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true
     },
     "object-assign": {
@@ -4703,9 +4658,9 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-keys": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
       "dev": true
     },
     "once": {
@@ -4726,9 +4681,9 @@
       }
     },
     "opener": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz",
-      "integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.0.tgz",
+      "integrity": "sha512-MD4s/o61y2slS27zm2s4229V2gAUHX0/e3/XOmY/jsXwhysjjCIHN8lx7gqZCrZk19ym+HjCUWHeMKD7YJtKCQ=="
     },
     "optionator": {
       "version": "0.8.2",
@@ -4747,8 +4702,7 @@
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "dev": true
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-locale": {
       "version": "2.1.0",
@@ -4763,8 +4717,16 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
     },
     "own-or": {
       "version": "1.0.0",
@@ -4787,17 +4749,25 @@
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-limit": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
+      "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+      "requires": {
+        "p-try": "^2.0.0"
+      }
     },
     "p-locate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "requires": {
-        "p-limit": "^1.1.0"
+        "p-limit": "^2.0.0"
       }
+    },
+    "p-try": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+      "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
     },
     "parallel-transform": {
       "version": "1.1.0",
@@ -4840,9 +4810,9 @@
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-parse": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
     "path-type": {
@@ -4853,6 +4823,12 @@
       "requires": {
         "pify": "^2.0.0"
       }
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
     },
     "performance-now": {
       "version": "2.1.0",
@@ -4891,6 +4867,15 @@
         "load-json-file": "^4.0.0"
       },
       "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
         "load-json-file": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -4902,6 +4887,40 @@
             "pify": "^3.0.0",
             "strip-bom": "^3.0.0"
           }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
         },
         "parse-json": {
           "version": "4.0.0",
@@ -4985,15 +5004,6 @@
       "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
       "dev": true
     },
-    "promise": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "dev": true,
-      "requires": {
-        "asap": "~2.0.3"
-      }
-    },
     "promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -5009,20 +5019,31 @@
       }
     },
     "prop-types": {
-      "version": "15.6.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
-      "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+      "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
       "dev": true,
       "requires": {
-        "fbjs": "^0.8.16",
         "loose-envify": "^1.3.1",
         "object-assign": "^4.1.1"
       }
+    },
+    "propagate": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-1.0.0.tgz",
+      "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=",
+      "dev": true
     },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+    },
+    "psl": {
+      "version": "1.1.29",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
+      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
+      "dev": true
     },
     "pump": {
       "version": "3.0.0",
@@ -5107,6 +5128,51 @@
       "requires": {
         "find-up": "^2.0.0",
         "read-pkg": "^2.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        }
       }
     },
     "readable-stream": {
@@ -5124,31 +5190,31 @@
       }
     },
     "request": {
-      "version": "2.87.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
-      "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+      "version": "2.88.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
-        "aws4": "^1.6.0",
+        "aws4": "^1.8.0",
         "caseless": "~0.12.0",
-        "combined-stream": "~1.0.5",
-        "extend": "~3.0.1",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
-        "form-data": "~2.3.1",
-        "har-validator": "~5.0.3",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
         "http-signature": "~1.2.0",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
         "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.17",
-        "oauth-sign": "~0.8.2",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
         "performance-now": "^2.1.0",
-        "qs": "~6.5.1",
-        "safe-buffer": "^5.1.1",
-        "tough-cookie": "~2.3.3",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
         "tunnel-agent": "^0.6.0",
-        "uuid": "^3.1.0"
+        "uuid": "^3.3.2"
       }
     },
     "require-directory": {
@@ -5181,9 +5247,9 @@
       }
     },
     "resolve": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
-      "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.5"
@@ -5274,21 +5340,14 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-      "dev": true
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
+      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
     },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-    },
-    "setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-      "dev": true
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -5315,14 +5374,6 @@
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "^2.0.0"
-      },
-      "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        }
       }
     },
     "smart-buffer": {
@@ -5331,9 +5382,9 @@
       "integrity": "sha512-RFqinRVJVcCAL9Uh1oVqE6FZkqsyLiVOYEZ20TqIOjuX7iFVJ+zsbs4RIghnw/pTs7mZvt8ZHhvm1ZUrR4fykg=="
     },
     "socks": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.2.0.tgz",
-      "integrity": "sha512-uRKV9uXQ9ytMbGm2+DilS1jB7N3AC0mmusmW5TVWjNuBZjxS8+lX38fasKVY9I4opv/bY/iqTbcpFFaTwpfwRg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.2.1.tgz",
+      "integrity": "sha512-0GabKw7n9mI46vcNrVfs0o6XzWzjVa3h6GaSo2UPxtWAROXUWavfJWh1M4PR5tnE0dcnQXZIDFP4yrAysLze/w==",
       "requires": {
         "ip": "^1.1.5",
         "smart-buffer": "^4.0.1"
@@ -5355,9 +5406,9 @@
       "dev": true
     },
     "source-map-support": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
-      "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
+      "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -5365,24 +5416,35 @@
       }
     },
     "spdx-correct": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+      "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "dev": true,
       "requires": {
-        "spdx-license-ids": "^1.0.2"
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
-    "spdx-expression-parse": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+    "spdx-exceptions": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
       "dev": true
     },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
     "spdx-license-ids": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
       "dev": true
     },
     "sprintf-js": {
@@ -5457,9 +5519,9 @@
       }
     },
     "stream-each": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
-      "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
+      "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
       "requires": {
         "end-of-stream": "^1.1.0",
         "stream-shift": "^1.0.0"
@@ -5476,32 +5538,12 @@
       "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string-width": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz",
-      "integrity": "sha1-AwZkVh/BRslCPsfZeP4kV0N/5tA=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "requires": {
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^4.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
       }
     },
     "string_decoder": {
@@ -5513,11 +5555,11 @@
       }
     },
     "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "^3.0.0"
       }
     },
     "strip-bom": {
@@ -5555,39 +5597,6 @@
         "lodash": "^4.17.4",
         "slice-ansi": "1.0.0",
         "string-width": "^2.1.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
       }
     },
     "tap": {
@@ -5625,14 +5634,6 @@
         "tsame": "^2.0.0",
         "write-file-atomic": "^2.3.0",
         "yapool": "^1.0.0"
-      },
-      "dependencies": {
-        "bluebird": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
-          "dev": true
-        }
       }
     },
     "tap-mocha-reporter": {
@@ -5660,12 +5661,6 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
         },
         "tap-parser": {
           "version": "5.4.0",
@@ -5728,11 +5723,12 @@
       }
     },
     "tough-cookie": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "dev": true,
       "requires": {
+        "psl": "^1.1.24",
         "punycode": "^1.4.1"
       }
     },
@@ -5778,16 +5774,16 @@
         "prelude-ls": "~1.1.2"
       }
     },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
-    },
-    "ua-parser-js": {
-      "version": "0.7.18",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
-      "integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA==",
-      "dev": true
     },
     "unicode-length": {
       "version": "1.0.3",
@@ -5797,6 +5793,23 @@
       "requires": {
         "punycode": "^1.3.2",
         "strip-ansi": "^3.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
       }
     },
     "uniq": {
@@ -5827,19 +5840,27 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
       "dev": true
     },
     "validate-npm-package-license": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
-        "spdx-correct": "~1.0.0",
-        "spdx-expression-parse": "~1.0.0"
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "validate-npm-package-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+      "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
+      "requires": {
+        "builtins": "^1.0.3"
       }
     },
     "verror": {
@@ -5853,16 +5874,10 @@
         "extsprintf": "^1.2.0"
       }
     },
-    "whatwg-fetch": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
-      "dev": true
-    },
     "which": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-      "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -5895,6 +5910,19 @@
         "strip-ansi": "^3.0.1"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -5903,6 +5931,14 @@
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
             "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
           }
         }
       }
@@ -5932,15 +5968,20 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "xregexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
+      "integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg=="
+    },
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "y18n": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
     },
     "yallist": {
       "version": "2.1.2",
@@ -5954,13 +5995,13 @@
       "dev": true
     },
     "yargs": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
-      "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.1.tgz",
+      "integrity": "sha512-B0vRAp1hRX4jgIOWFtjfNjd9OA9RWYZ6tqGA9/I/IrTMsxmKvtWy+ersM+jzpQqbC3YfLzeABPdeTgcJ9eu1qQ==",
       "requires": {
         "cliui": "^4.0.0",
-        "decamelize": "^1.1.1",
-        "find-up": "^2.1.0",
+        "decamelize": "^2.0.0",
+        "find-up": "^3.0.0",
         "get-caller-file": "^1.0.1",
         "os-locale": "^2.0.0",
         "require-directory": "^2.1.1",
@@ -5968,14 +6009,14 @@
         "set-blocking": "^2.0.0",
         "string-width": "^2.0.0",
         "which-module": "^2.0.0",
-        "y18n": "^3.2.1",
-        "yargs-parser": "^9.0.2"
+        "y18n": "^3.2.1 || ^4.0.0",
+        "yargs-parser": "^10.1.0"
       }
     },
     "yargs-parser": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
-      "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+      "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
       "requires": {
         "camelcase": "^4.1.0"
       }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1976,9 +1976,9 @@
       }
     },
     "npm-registry-fetch": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-3.4.0.tgz",
-      "integrity": "sha512-w1Fnl0a1ZbvSiUVwbEPRhbBTVTnZis+YCfsqqikuvvXxZZXUIN1++FqxCyoTawjZPDOTYbPE9hYWiJL7skgSpg==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-3.5.0.tgz",
+      "integrity": "sha512-9LhdRrd5kHDXVpaj7HF1RyN2B9Z8Ib/Ed2RcBWlM4UmXRfiIAwc0OarJFSgDne0DiY09NbxhEOflXqC5auu49g==",
       "requires": {
         "bluebird": "^3.5.1",
         "figgy-pudding": "^3.4.1",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1976,12 +1976,12 @@
       }
     },
     "npm-registry-fetch": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-3.3.0.tgz",
-      "integrity": "sha512-LlJnM1BR3X9WxcJksur4+tSmo6RpXd3gdjQUQpkI/u8pKGP/kSbCV7XWE5DVgHslCiq5GBVonDqmutrCntIu3Q==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-3.4.0.tgz",
+      "integrity": "sha512-w1Fnl0a1ZbvSiUVwbEPRhbBTVTnZis+YCfsqqikuvvXxZZXUIN1++FqxCyoTawjZPDOTYbPE9hYWiJL7skgSpg==",
       "requires": {
         "bluebird": "^3.5.1",
-        "figgy-pudding": "^3.2.0",
+        "figgy-pudding": "^3.4.1",
         "lru-cache": "^4.1.3",
         "make-fetch-happen": "^4.0.1",
         "npm-package-arg": "^6.1.0"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1976,9 +1976,9 @@
       }
     },
     "npm-registry-fetch": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-3.5.0.tgz",
-      "integrity": "sha512-9LhdRrd5kHDXVpaj7HF1RyN2B9Z8Ib/Ed2RcBWlM4UmXRfiIAwc0OarJFSgDne0DiY09NbxhEOflXqC5auu49g==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-3.6.0.tgz",
+      "integrity": "sha512-grqgeWO0SQ0o7WiZD2fRETSqjfXxcYM++44exkENWMbV2xOPGjb7vgMsHmnTiW/GjRyta/H2yF8hQIEyf63n8A==",
       "requires": {
         "bluebird": "^3.5.1",
         "figgy-pudding": "^3.4.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "figgy-pudding": "^3.4.1",
     "ini": "^1.3.4",
     "is-cidr": "^2.0.6",
-    "npm-registry-fetch": "^3.4.0",
+    "npm-registry-fetch": "^3.5.0",
     "npm-user-validate": "^1.0.0",
     "npmlog": "*",
     "opener": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "figgy-pudding": "^3.4.1",
     "ini": "^1.3.4",
     "is-cidr": "^2.0.6",
-    "npm-registry-fetch": "^3.5.0",
+    "npm-registry-fetch": "^3.6.0",
     "npm-user-validate": "^1.0.0",
     "npmlog": "*",
     "opener": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -12,30 +12,32 @@
     "aproba": "^1.1.2 || 2",
     "bluebird": "^3.5.0",
     "cliui": "^4.1.0",
+    "figgy-pudding": "^3.4.1",
     "ini": "^1.3.4",
-    "is-cidr": "^1.0.0",
-    "make-fetch-happen": "^2.5.0 || 3 || 4",
+    "is-cidr": "^2.0.6",
+    "npm-registry-fetch": "^3.3.0",
     "npm-user-validate": "^1.0.0",
     "npmlog": "*",
-    "opener": "^1.4.3",
+    "opener": "^1.5.0",
     "qrcode-terminal": "^0.12.0",
     "query-string": "^6.1.0",
     "read": "^1.0.7",
     "treeify": "^1.0.1",
-    "yargs": "^11.0.0"
+    "yargs": "^12.0.1"
   },
   "main": "index.js",
   "directories": {
     "lib": "lib"
   },
   "devDependencies": {
+    "nock": "^9.2.3",
     "require-inject": "^1.4.2",
     "standard": "^11.0.1",
     "tap": "^12.0.1"
   },
   "scripts": {
-    "test": "standard && tap lib/test --cov --nyc-arg=--include=lib/*.js",
-    "snap": "TAP_SNAPSHOT=1 tap lib/test"
+    "test": "standard && tap lib/test/*.js --cov --100 --nyc-arg=--include=lib/*.js",
+    "snap": "TAP_SNAPSHOT=1 tap lib/test/*.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "figgy-pudding": "^3.4.1",
     "ini": "^1.3.4",
     "is-cidr": "^2.0.6",
-    "npm-registry-fetch": "^3.3.0",
+    "npm-registry-fetch": "^3.4.0",
     "npm-user-validate": "^1.0.0",
     "npmlog": "*",
     "opener": "^1.5.0",


### PR DESCRIPTION
This is the refactor to make `npm-profile` use the new registry fetch library, which makes it so we can consistently handle all the various incidentals of networking stuff and config and all that jazz without random adapters in npm core.

This is a **BREAKING CHANGE** because it's changing the options behavior. I've updated all the docs to reflect this, since most of those configs will now go through `n-r-f`.