### PR TITLE
allow uri-safe usernames

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -145,7 +145,7 @@ function adduserCouch (username, email, password, opts) {
   })
   process.emit('log', 'verbose', 'adduser', 'before first PUT', logObj)
 
-  const target = '/-/user/org.couchdb.user:' + encodeURIComponent(username)
+  const target = '/-/user/org.couchdb.user:' + encodeURIComponent(decodeURIComponent(username))
   return fetch.json(target, opts.concat({
     method: 'PUT',
     body
@@ -172,7 +172,7 @@ function loginCouch (username, password, opts) {
   })
   process.emit('log', 'verbose', 'login', 'before first PUT', logObj)
 
-  const target = '-/user/org.couchdb.user:' + encodeURIComponent(username)
+  const target = '-/user/org.couchdb.user:' + encodeURIComponent(decodeURIComponent(username))
   return fetch.json(target, opts.concat({
     method: 'PUT',
     body


### PR DESCRIPTION
Related to https://github.com/npm/npm-user-validate/issues/12, email addresses are valid usernames in some systems.

Currently, even if the user validator supports email addresses (as uri-safe usernames), this will encode them again turning `%` characters into `%25`.

This implementation will ensure backward compatibility with anything currently depending on it by decoding before re-encoding.  Non-encoded strings will still be encoded, but already encoded strings will not be double encoded.