### PR TITLE
feat: set 'npm-use-webauthn' header depending on option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -60,7 +60,7 @@ const webAuth = (opener, opts, body) => {
     method: 'POST',
     body,
     headers: {
-      'npm-use-webauth': opts.authType === 'webauthn',
+      'npm-use-webauthn': opts.authType === 'webauthn',
     },
   }).then(res => {
     return Promise.all([res, res.json()])

--- a/lib/index.js
+++ b/lib/index.js
@@ -59,6 +59,9 @@ const webAuth = (opener, opts, body) => {
     ...opts,
     method: 'POST',
     body,
+    headers: {
+      'npm-use-webauth': opts.useWebauth,
+    },
   }).then(res => {
     return Promise.all([res, res.json()])
   }).then(([res, content]) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -60,7 +60,7 @@ const webAuth = (opener, opts, body) => {
     method: 'POST',
     body,
     headers: {
-      'npm-use-webauth': opts.useWebauth,
+      'npm-use-webauth': opts.authType === 'webauthn',
     },
   }).then(res => {
     return Promise.all([res, res.json()])


### PR DESCRIPTION
We want to be able to opt in to web logins. To do that, we need to pass a header to the registry so it knows which flow to run.
The option originates from the [CLI](https://github.com/npm/cli/pull/4931).


## References
- Closes: github/npm#5315
- Related: npm/cli#4931
- Parent Issue: github/npm#4897