### PR TITLE
feat: Allow the done-check for web login to cancel opener promise

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@
 
 const fetch = require('npm-registry-fetch')
 const { HttpErrorBase } = require('npm-registry-fetch/lib/errors')
+const EventEmitter = require('events')
 const os = require('os')
 const { URL } = require('url')
 const log = require('proc-log')
@@ -73,8 +74,23 @@ const webAuth = (opener, opts, body) => {
     return content
   }).then(({ doneUrl, loginUrl }) => {
     log.verbose('web auth', 'opening url pair')
-    return opener(loginUrl).then(
-      () => webAuthCheckLogin(doneUrl, { ...opts, cache: false })
+
+    const doneEmitter = new EventEmitter()
+
+    const openPromise = opener(loginUrl, doneEmitter)
+    const webAuthCheckPromise = webAuthCheckLogin(doneUrl, { ...opts, cache: false })
+      .then(authResult => {
+        log.verbose('web auth', 'done-check finished')
+
+        // cancel open prompt if it's present
+        doneEmitter.emit('abort')
+
+        return authResult
+      })
+
+    return Promise.all([openPromise, webAuthCheckPromise]).then(
+      // pick the auth result and pass it along
+      ([, authResult]) => authResult
     )
   }).catch(er => {
     if ((er.statusCode >= 400 && er.statusCode <= 499) || er.statusCode === 500) {


### PR DESCRIPTION
## What
- Run the URL opener and the done-check promises in parallel
- Finish when both promises are resolved
- Allow the done-check to resolve the opener promise

## Why
Allows the npm CLI to prompt and wait before opening a URL, while having the flow dependent on the authorization result.

## References
- Dependent of: npm/cli#4960
- Main Issue: github/npm#5312
- Parent Issue: github/npm#4897