### PR TITLE
feat!: Remove `npm-use-webauthn` header

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -60,9 +60,6 @@ const webAuth = (opener, opts, body) => {
     ...opts,
     method: 'POST',
     body,
-    headers: {
-      'npm-use-webauthn': opts.authType === 'webauthn',
-    },
   }).then(res => {
     return Promise.all([res, res.json()])
   }).then(([res, content]) => {


### PR DESCRIPTION
## What
Remove the `npm-use-webauthn` header.

## Why
The `npm-auth-type` header set in the `npm-registry-fetch` package will be used instead.

## References
- Related https://github.com/github/npm/issues/5498
- Dependent on https://github.com/npm/npm-registry-fetch/pull/124
- Related to https://github.com/npm/npm-registry-fetch/pull/123
- Resolves https://github.com/github/npm/issues/5577