### PR TITLE
feat: renamed the 'npm-use-webauthn' header to 'npm-auth-type'

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,7 @@ const webAuth = (opener, opts, body) => {
     method: 'POST',
     body,
     headers: {
-      'npm-use-webauthn': opts.authType === 'webauthn',
+      'npm-auth-type': opts.authType
     },
   }).then(res => {
     return Promise.all([res, res.json()])

--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,7 @@ const webAuth = (opener, opts, body) => {
     method: 'POST',
     body,
     headers: {
-      'npm-auth-type': opts.authType
+      'npm-auth-type': opts.authType,
     },
   }).then(res => {
     return Promise.all([res, res.json()])


### PR DESCRIPTION
<!-- What / Why -->
change the `npm-use-webauthn` header to `npm-auth-type` to support the new `login` and `publish` flow
See https://github.com/npm/npm-registry-fetch/pull/123#discussion_r905333143
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
  * Related to https://github.com/github/npm/issues/5496
  * Related to https://github.com/github/npm/issues/4897
  * Related to https://github.com/github/npm/issues/5499
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
