### PR TITLE
fix: Cancel opener promise if web login fails

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -78,7 +78,7 @@ const webAuth = (opener, opts, body) => {
     const doneEmitter = new EventEmitter()
 
     const openPromise = opener(loginUrl, doneEmitter)
-    const webAuthCheckPromise = webAuthCheckLogin(doneUrl, { ...opts, cache: false })
+    const webAuthCheckPromise = webAuthCheckLogin(doneUrl, { ...opts, cache: false, doneEmitter })
       .then(authResult => {
         log.verbose('web auth', 'done-check finished')
 
@@ -124,6 +124,11 @@ const webAuthCheckLogin = (doneUrl, opts) => {
     } else {
       throw new WebLoginInvalidResponse('GET', res, content)
     }
+  }).catch(er => {
+    // cancel open prompt if it's present
+    opts.doneEmitter?.emit('abort')
+
+    throw er
   })
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -56,6 +56,7 @@ const webAuth = (opener, opts, body) => {
   const { hostname } = opts
   body.hostname = hostname || os.hostname()
   const target = '/-/v1/login'
+  const doneEmitter = new EventEmitter()
   return fetch(target, {
     ...opts,
     method: 'POST',
@@ -75,10 +76,8 @@ const webAuth = (opener, opts, body) => {
   }).then(({ doneUrl, loginUrl }) => {
     log.verbose('web auth', 'opening url pair')
 
-    const doneEmitter = new EventEmitter()
-
     const openPromise = opener(loginUrl, doneEmitter)
-    const webAuthCheckPromise = webAuthCheckLogin(doneUrl, { ...opts, cache: false, doneEmitter })
+    const webAuthCheckPromise = webAuthCheckLogin(doneUrl, { ...opts, cache: false })
       .then(authResult => {
         log.verbose('web auth', 'done-check finished')
 
@@ -93,6 +92,9 @@ const webAuth = (opener, opts, body) => {
       ([, authResult]) => authResult
     )
   }).catch(er => {
+    // cancel open prompt if it's present
+    doneEmitter.emit('abort')
+
     if ((er.statusCode >= 400 && er.statusCode <= 499) || er.statusCode === 500) {
       throw new WebLoginNotSupported('POST', {
         status: er.statusCode,
@@ -124,13 +126,6 @@ const webAuthCheckLogin = (doneUrl, opts) => {
     } else {
       throw new WebLoginInvalidResponse('GET', res, content)
     }
-  }).catch(er => {
-    // cancel open prompt if it's present
-    if (opts.doneEmitter) {
-      opts.doneEmitter.emit('abort')
-    }
-
-    throw er
   })
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -126,7 +126,9 @@ const webAuthCheckLogin = (doneUrl, opts) => {
     }
   }).catch(er => {
     // cancel open prompt if it's present
-    opts.doneEmitter?.emit('abort')
+    if (opts.doneEmitter) {
+      opts.doneEmitter.emit('abort')
+    }
 
     throw er
   })

--- a/test/index.js
+++ b/test/index.js
@@ -16,7 +16,7 @@ test('get', t => {
     return [auth ? 200 : 401, '', {}]
   })
   return profile.get().then(result => {
-    t.fail('GET w/o auth should fail')
+    return t.fail('GET w/o auth should fail')
   }, err => {
     t.equal(err.code, 'E401', 'auth errors are passed through')
   }).then(() => {
@@ -27,7 +27,7 @@ test('get', t => {
     })
     return profile.get({ '//registry.npmjs.org/:_authToken': 'deadbeef' })
   }).then(result => {
-    t.match(result, { auth: 'bearer' })
+    return t.match(result, { auth: 'bearer' })
   }).then(() => {
     srv.get(getUrl).reply(function () {
       const auth = this.req.headers.authorization
@@ -46,7 +46,7 @@ test('get', t => {
       '//registry.npmjs.org/:_password': Buffer.from('123', 'utf8').toString('base64'),
     })
   }).then(result => {
-    t.match(result, { auth: 'basic' })
+    return t.match(result, { auth: 'basic' })
   }).then(() => {
     srv.get(getUrl).reply(function () {
       const auth = this.req.headers.authorization
@@ -60,7 +60,7 @@ test('get', t => {
       '//registry.npmjs.org/:_authToken': 'deadbeef',
     })
   }).then(result => {
-    t.match(result, { auth: 'bearer', otp: true })
+    return t.match(result, { auth: 'bearer', otp: true })
   })
   // with otp, with token, with basic
   // prob should make w/o token 401
@@ -76,7 +76,7 @@ test('set', t => {
     github: 'zkat',
     email: '',
   }).then(json => {
-    t.same(json, prof, 'got the profile data in return')
+    return t.same(json, prof, 'got the profile data in return')
   })
 })
 
@@ -258,7 +258,7 @@ test('listTokens multipage', t => {
     urls: {},
   })
   return profile.listTokens().then(tok => {
-    t.same(
+    return t.same(
       tok,
       tokens1.concat(tokens2).concat(tokens3),
       'supports multi-URL token requests and concats them'
@@ -269,7 +269,7 @@ test('listTokens multipage', t => {
 test('removeToken', t => {
   tnock(t, registry).delete('/-/npm/v1/tokens/token/deadbeef').reply(200)
   return profile.removeToken('deadbeef').then(ret => {
-    t.equal(ret, null, 'null return value on success')
+    return t.equal(ret, null, 'null return value on success')
   })
 })
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
This PR adds logic to cancel opener promise if web login fails and we fall back to couch login. The opener promise was previously still awaiting user to press Enter and interfering with input on terminal for couch login as shown in 👇🏻 screen recordings.

Also fixed few unrelated lint failures in https://github.com/npm/npm-profile/pull/57/commits/dfe769f857290aa37178fbcabf5ed3ed1ba4f4e0 which started failing due to new [`eslint-config` ](https://github.com/npm/eslint-config) rules enabled in https://github.com/npm/eslint-config/pull/34. These lint fixes may not be required after https://github.com/npm/eslint-config/pull/38 is merged though.. 🤔

### Before Fix
https://user-images.githubusercontent.com/73886592/182330643-99b3ef46-e332-4c04-af95-31cb8dad2e10.mov

### After Fix
https://user-images.githubusercontent.com/73886592/182332716-a649e790-1d6c-4d70-8f08-496bc172e662.mov

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
- Resolves npm/cli#5230