### PR TITLE
fix: exit handler error on login

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -119,7 +119,7 @@ const webAuthCheckLogin = async (doneUrl, opts, { signal } = {}) => {
   if (res.status === 202) {
     const retry = +res.headers.get('retry-after') * 1000
     if (retry > 0) {
-      await timers.setTimeout(retry, null, { ref: false, signal })
+      await timers.setTimeout(retry, null, { signal })
     }
     return webAuthCheckLogin(doneUrl, opts, { signal })
   }


### PR DESCRIPTION
One of the possible cause that the exit handler never called happens is when this timer doesn't keep event loop active when `ref` is set to `false`. Removing set it to true by default. 

