### PR TITLE
feat!: support granular access tokens in token management, deprecate classic token creation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -225,25 +225,36 @@ const paginate = async (href, opts, items = []) => {
   return items
 }
 
-const listTokens = (opts = {}) => paginate('/-/npm/v1/tokens', opts)
+const listTokens = async (opts = {}) => {
+  const [tokens, userTokens] = await Promise.all([
+    paginate('/-/npm/v1/tokens', opts),
+    paginate('/-/npm/v1/user/tokens', opts),
+  ])
+  return tokens.concat(userTokens)
+}
 
 const removeToken = async (tokenKey, opts = {}) => {
-  await fetch(`/-/npm/v1/tokens/token/${tokenKey}`, {
-    ...opts,
-    method: 'DELETE',
-    ignoreBody: true,
-  })
+  try {
+    await fetch(`/-/npm/v1/tokens/token/${tokenKey}`, {
+      ...opts,
+      method: 'DELETE',
+      ignoreBody: true,
+    })
+  } catch (err) {
+    // If classic token deletion fails, try GAT endpoint
+    await fetch(`/-/npm/v1/user/tokens/${tokenKey}`, {
+      ...opts,
+      method: 'DELETE',
+      ignoreBody: true,
+    })
+  }
   return null
 }
 
-const createToken = (password, readonly, cidrs, opts = {}) => fetch.json('/-/npm/v1/tokens', {
+const createToken = (tokenData, opts = {}) => fetch.json('/-/npm/v1/user/tokens', {
   ...opts,
   method: 'POST',
-  body: {
-    password: password,
-    readonly: readonly,
-    cidr_whitelist: cidrs,
-  },
+  body: tokenData,
 })
 
 class WebLoginInvalidResponse extends HttpErrorBase {


### PR DESCRIPTION
BREAKING CHANGE: The createToken and removeToken functions have been updated to support granular access tokens. The previous method of creating classic tokens is deprecated. Please use the new createToken function with appropriate parameters for granular tokens.
- Granular access tokens will now show in the listTokens function alongside classic tokens.
- Remove token should now handle both classic and granular tokens appropriately.