### PR TITLE
feat: support for creating granular access tokens

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -246,6 +246,12 @@ const createToken = (password, readonly, cidrs, opts = {}) => fetch.json('/-/npm
   },
 })
 
+const createGatToken = (tokenData, opts = {}) => fetch.json('/-/npm/v1/tokens', {
+  ...opts,
+  method: 'POST',
+  body: tokenData,
+})
+
 class WebLoginInvalidResponse extends HttpErrorBase {
   constructor (method, res, body) {
     super(method, res, body)
@@ -273,6 +279,7 @@ module.exports = {
   listTokens,
   removeToken,
   createToken,
+  createGatToken,
   webAuthCheckLogin,
   webAuthOpener,
 }

--- a/test/index.js
+++ b/test/index.js
@@ -289,3 +289,26 @@ test('createToken', t => {
     base.cidr_whitelist
   ).then(ret => t.same(ret, obj, 'got the right return value'))
 })
+
+test('createGatToken', t => {
+  const tokenData = {
+    type: 'granular',
+    name: 'CI Publish Token',
+    access: 'read-write',
+    expires: '2025-12-01T00:00:00Z',
+    packages: ['@my-org/my-package'],
+    scopes: ['@my-org'],
+    cidr_whitelist: ['8.8.8.8/32'],
+  }
+  const response = {
+    id: '789abc',
+    token: 'npm_gat_abcdef',
+    name: 'CI Publish Token',
+    type: 'granular',
+    access: 'read-write',
+    expires: '2025-12-01T00:00:00Z',
+    created: '2025-04-15T08:20:00Z',
+  }
+  tnock(t, registry).post('/-/npm/v1/tokens', tokenData).reply(201, response)
+  return profile.createGatToken(tokenData).then(ret => t.same(ret, response, 'got the right return value'))
+})


### PR DESCRIPTION
This pull request introduces support for creating granular access tokens (GATs) via the npm API, along with a corresponding test to ensure correct functionality. The main changes include adding a new method for GAT creation, exporting it for external use, and verifying its behavior with a unit test.