### PR TITLE
fix: poll web-login done-check on the configured registry origin

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,6 +31,35 @@ const isValidUrl = u => {
   }
 }
 
+// npm's web-login response names the canonical npmjs registry in `doneUrl`, which a proxy/mirror forwards verbatim.
+// The poll would then hit npmjs.org instead of the proxy that holds the session, so rewrite only that npmjs host to the configured registry origin, preserving the path prefix and query string.
+// Any other done host is left untouched, since a non-npmjs canonical host cannot be inferred here and may be served intentionally.
+const CANONICAL_REGISTRY_HOST = 'registry.npmjs.org'
+
+const replaceDoneUrlOrigin = (doneUrl, registry) => {
+  if (!registry) {
+    return doneUrl
+  }
+  try {
+    const done = new URL(doneUrl)
+    if (done.hostname !== CANONICAL_REGISTRY_HOST) {
+      return doneUrl
+    }
+    const reg = new URL(registry)
+    done.protocol = reg.protocol
+    done.host = reg.host
+    const prefix = reg.pathname.replace(/\/$/, '')
+    if (prefix && prefix !== '/' &&
+        done.pathname !== prefix &&
+        !done.pathname.startsWith(prefix + '/')) {
+      done.pathname = prefix + done.pathname
+    }
+    return done.href
+  } catch {
+    return doneUrl
+  }
+}
+
 const webAuth = async (opener, opts, body) => {
   try {
     const res = await fetch('/-/v1/login', {
@@ -47,7 +76,7 @@ const webAuth = async (opener, opts, body) => {
       throw new WebLoginInvalidResponse('POST', res, content)
     }
 
-    return await webAuthOpener(opener, loginUrl, doneUrl, opts)
+    return await webAuthOpener(opener, loginUrl, replaceDoneUrlOrigin(doneUrl, opts.registry), opts)
   } catch (er) {
     if ((er.statusCode >= 400 && er.statusCode <= 499) || er.statusCode === 500) {
       throw new WebLoginNotSupported('POST', {

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,28 +36,26 @@ const isValidUrl = u => {
 // Any other done host is left untouched, since a non-npmjs canonical host cannot be inferred here and may be served intentionally.
 const CANONICAL_REGISTRY_HOST = 'registry.npmjs.org'
 
+// doneUrl is already validated by isValidUrl and registry is the origin a prior
+// POST /-/v1/login succeeded against, so both parse cleanly here.
 const replaceDoneUrlOrigin = (doneUrl, registry) => {
   if (!registry) {
     return doneUrl
   }
-  try {
-    const done = new URL(doneUrl)
-    if (done.hostname !== CANONICAL_REGISTRY_HOST) {
-      return doneUrl
-    }
-    const reg = new URL(registry)
-    done.protocol = reg.protocol
-    done.host = reg.host
-    const prefix = reg.pathname.replace(/\/$/, '')
-    if (prefix && prefix !== '/' &&
-        done.pathname !== prefix &&
-        !done.pathname.startsWith(prefix + '/')) {
-      done.pathname = prefix + done.pathname
-    }
-    return done.href
-  } catch {
+  const done = new URL(doneUrl)
+  if (done.hostname !== CANONICAL_REGISTRY_HOST) {
     return doneUrl
   }
+  const reg = new URL(registry)
+  done.protocol = reg.protocol
+  done.host = reg.host
+  const prefix = reg.pathname.replace(/\/$/, '')
+  if (prefix && prefix !== '/' &&
+      done.pathname !== prefix &&
+      !done.pathname.startsWith(prefix + '/')) {
+    done.pathname = prefix + done.pathname
+  }
+  return done.href
 }
 
 const webAuth = async (opener, opts, body) => {

--- a/test/index.js
+++ b/test/index.js
@@ -158,6 +158,111 @@ test('login fallback to couch when web login fails cancels opener promise', t =>
   })
 })
 
+test('web login done-check follows the configured registry origin and port', t => {
+  // The mirror runs on a non-default port to verify host+port are both rewritten.
+  const mirror = 'https://mirror.example.com:8443/'
+  const loginUrl = 'https://www.npmjs.com/login?next=/login/cli/123'
+  // The mirror issues the session but returns a doneUrl on the canonical
+  // registry host; the poll must go back to the mirror, not registry.npmjs.org.
+  tnock(t, mirror)
+    .post('/-/v1/login')
+    .reply(200, {
+      loginUrl,
+      doneUrl: 'https://registry.npmjs.org/-/v1/done?sessionId=123',
+    })
+    .get('/-/v1/done?sessionId=123')
+    .reply(200, { token: 'success' })
+
+  const opener = async url => {
+    t.equal(url, loginUrl, 'browser still opens the canonical login url')
+  }
+
+  return t.resolveMatch(profile.loginWeb(opener, { registry: mirror }), {
+    token: 'success',
+  })
+})
+
+test('web login done-check preserves the registry path prefix', t => {
+  const proxy = 'https://corp.example.com/npm-proxy/'
+  const loginUrl = 'https://www.npmjs.com/login?next=/login/cli/456'
+  tnock(t, 'https://corp.example.com')
+    .post('/npm-proxy/-/v1/login')
+    .reply(200, {
+      loginUrl,
+      doneUrl: 'https://registry.npmjs.org/-/v1/done?sessionId=456',
+    })
+    .get('/npm-proxy/-/v1/done?sessionId=456')
+    .reply(200, { token: 'prefixed' })
+
+  const opener = async () => {}
+
+  return t.resolveMatch(profile.loginWeb(opener, { registry: proxy }), {
+    token: 'prefixed',
+  })
+})
+
+test('web login done-check does not double the registry path prefix', t => {
+  const proxy = 'https://corp.example.com/npm-proxy/'
+  const loginUrl = 'https://www.npmjs.com/login?next=/login/cli/654'
+  tnock(t, 'https://corp.example.com')
+    .post('/npm-proxy/-/v1/login')
+    .reply(200, {
+      loginUrl,
+      // doneUrl already carries the proxy path prefix, just on the canonical host.
+      doneUrl: 'https://registry.npmjs.org/npm-proxy/-/v1/done?sessionId=654',
+    })
+    .get('/npm-proxy/-/v1/done?sessionId=654')
+    .reply(200, { token: 'not-doubled' })
+
+  const opener = async () => {}
+
+  return t.resolveMatch(profile.loginWeb(opener, { registry: proxy }), {
+    token: 'not-doubled',
+  })
+})
+
+test('web login through a mirror succeeds without falling back to couch', t => {
+  const mirror = 'https://mirror.example.com/'
+  const loginUrl = 'https://www.npmjs.com/login?next=/login/cli/789'
+  tnock(t, mirror)
+    .post('/-/v1/login')
+    .reply(200, {
+      loginUrl,
+      doneUrl: 'https://registry.npmjs.org/-/v1/done?sessionId=789',
+    })
+    .get('/-/v1/done?sessionId=789')
+    .reply(200, { token: 'success' })
+
+  const opener = async () => {}
+  const prompter = () => t.fail('should not fall back to couch prompter')
+
+  return t.resolveMatch(profile.login(opener, prompter, { registry: mirror }), {
+    token: 'success',
+  })
+})
+
+test('web login leaves a non-canonical done host untouched', t => {
+  // A registry that intentionally serves the done endpoint on a separate host
+  // must be honored, not rewritten to the configured registry origin.
+  const mirror = 'https://mirror.example.com/'
+  const loginUrl = 'https://www.npmjs.com/login?next=/login/cli/abc'
+  tnock(t, mirror)
+    .post('/-/v1/login')
+    .reply(200, {
+      loginUrl,
+      doneUrl: 'https://auth.example.com/-/v1/done?sessionId=abc',
+    })
+  tnock(t, 'https://auth.example.com')
+    .get('/-/v1/done?sessionId=abc')
+    .reply(200, { token: 'custom-host' })
+
+  const opener = async () => {}
+
+  return t.resolveMatch(profile.loginWeb(opener, { registry: mirror }), {
+    token: 'custom-host',
+  })
+})
+
 test('loginWeb fail, just testing default opts setting', t => {
   tnock(t, registry)
     .post('/-/v1/login')


### PR DESCRIPTION
`npm login --auth-type=web` (the default) silently fails behind a proxy/mirror registry, then falls back to legacy couch auth, which also fails:

```
npm error code E401 - Incorrect or missing password
# or, depending on the proxy:
npm error Exit handler never called!
npm error code E405 - 405 Not Allowed - PUT .../-/user/org.couchdb.user:<name>
```

This is the common proxy/mirror case: the machine (or CI) is configured to use a private registry proxy/mirror with a different origin than `registry.npmjs.org`.

## Why

Web login does two requests against the configured registry: a `POST /-/v1/login` that returns a `loginUrl` (opened in the browser) and a `doneUrl` (polled by npm until the token is issued).

A proxy/mirror forwards npm's response verbatim, so the `doneUrl` it returns points at the canonical `https://registry.npmjs.org/-/v1/done?...`, not at the proxy that actually created the session.
`webAuth` used that `doneUrl` as-is, so npm polled `registry.npmjs.org` directly and got a `403` (the session lives on the proxy, not on the public registry).
`webAuth` treats any `4xx`/`500` as "web login not supported" and falls back to couch (`PUT /-/user/...`), which proxies commonly reject (`405`/`401`) — the dead end users actually see.

This is the login analog of npm/cli#9550: a canonical `registry.npmjs.org` URL handed back by the server must be host-rewritten to the configured registry origin before npm fetches it.

## How

`replaceDoneUrlOrigin(doneUrl, opts.registry)` rewrites the `doneUrl` to the configured registry's origin before polling, preserving any registry path prefix and the query string.
The session is created by the `POST /-/v1/login` to `opts.registry`, so the done-check must poll that same registry.

The rewrite is gated on the canonical npmjs host (`done.hostname === 'registry.npmjs.org'`), mirroring the conservative default of npm/cli#9550:

- A proxy/mirror that leaks the canonical `registry.npmjs.org` `doneUrl` is corrected to poll the proxy.
- A registry that intentionally serves the done endpoint on its own/other host is left untouched (a non-npmjs canonical host cannot be inferred here).
- A non-proxied npmjs login is a no-op (same origin, no path prefix).

The browser-facing `loginUrl` is never rewritten.

## References

Fixes npm/cli#8875
Related: npm/cli#9550